### PR TITLE
Explicitly depend on react/stream

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
         "php": ">=5.4.0",
         "react/dns": "0.4.*",
         "react/event-loop": "0.4.*",
+        "react/stream": "0.4.*",
         "react/promise": "~2.0"
     },
     "autoload": {


### PR DESCRIPTION
The code has an explicit dependency on React's `stream` component, hence we should explicitly define it as a dependency.

Currently, it's (implicitly) installed as part of a dependency of the `dns` component. IMHO this is an implementation detail that we should not rely on.
