### PR TITLE
Now connects to a given address string instead of a port number.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ succeeds or fails.
 ```php
 $connector = new React\SocketClient\Connector($loop, $dns);
 
-$connector->create('www.google.com', 80)->then(function (React\Stream\Stream $stream) {
+$connector->create('www.google.com:80')->then(function (React\Stream\Stream $stream) {
     $stream->write('...');
     $stream->close();
 });
@@ -57,7 +57,7 @@ a `Stream` instance that can be used just like any non-encrypted stream.
 ```php
 $secureConnector = new React\SocketClient\SecureConnector($connector, $loop);
 
-$secureConnector->create('www.google.com', 443)->then(function (React\Stream\Stream $stream) {
+$secureConnector->create('www.google.com:443')->then(function (React\Stream\Stream $stream) {
     $stream->write("GET / HTTP/1.0\r\nHost: www.google.com\r\n\r\n");
     ...
 });

--- a/src/ConnectorInterface.php
+++ b/src/ConnectorInterface.php
@@ -4,5 +4,5 @@ namespace React\SocketClient;
 
 interface ConnectorInterface
 {
-    public function create($host, $port);
+    public function create($address);
 }

--- a/src/SecureConnector.php
+++ b/src/SecureConnector.php
@@ -16,9 +16,9 @@ class SecureConnector implements ConnectorInterface
         $this->streamEncryption = new StreamEncryption($loop);
     }
 
-    public function create($host, $port)
+    public function create($address)
     {
-        return $this->connector->create($host, $port)->then(function (Stream $stream) {
+        return $this->connector->create($address)->then(function (Stream $stream) {
             // (unencrypted) connection succeeded => try to enable encryption
             return $this->streamEncryption->enable($stream)->then(null, function ($error) use ($stream) {
                 // establishing encryption failed => close invalid connection and return error

--- a/tests/ConnectorTest.php
+++ b/tests/ConnectorTest.php
@@ -16,7 +16,7 @@ class ConnectorTest extends TestCase
         $dns = $this->createResolverMock();
 
         $connector = new Connector($loop, $dns);
-        $connector->create('127.0.0.1', 9999)
+        $connector->create('127.0.0.1:9999')
                 ->then($this->expectCallableNever(), $this->expectCallableOnce());
 
         $loop->run();
@@ -39,7 +39,7 @@ class ConnectorTest extends TestCase
         $dns = $this->createResolverMock();
 
         $connector = new Connector($loop, $dns);
-        $connector->create('127.0.0.1', 9999)
+        $connector->create('127.0.0.1:9999')
                 ->then(function ($stream) use (&$capturedStream) {
                     $capturedStream = $stream;
                     $stream->end();
@@ -59,7 +59,7 @@ class ConnectorTest extends TestCase
 
         $connector = new Connector($loop, $dns);
         $connector
-            ->create('::1', 9999)
+            ->create('[::1]:9999')
             ->then($this->expectCallableNever(), $this->expectCallableOnce());
 
         $loop->run();
@@ -81,7 +81,7 @@ class ConnectorTest extends TestCase
 
         $connector = new Connector($loop, $dns);
         $connector
-            ->create('::1', 9999)
+            ->create('[::1]:9999')
             ->then(function ($stream) use (&$capturedStream) {
                 $capturedStream = $stream;
                 $stream->end();


### PR DESCRIPTION
The unit tests will need to be updated later on to run against the same changes to the socket component.
