### PR TITLE
Ensure SNI details are always set on socket creation

### DIFF
--- a/src/Connector.php
+++ b/src/Connector.php
@@ -23,16 +23,24 @@ class Connector implements ConnectorInterface
     {
         return $this
             ->resolveHostname($host)
-            ->then(function ($address) use ($port) {
-                return $this->createSocketForAddress($address, $port);
+            ->then(function ($address) use ($port, $host) {
+                return $this->createSocketForAddress($address, $port, $host);
             });
     }
 
-    public function createSocketForAddress($address, $port)
+    public function createSocketForAddress($address, $port, $hostName = null)
     {
         $url = $this->getSocketUrl($address, $port);
 
-        $socket = stream_socket_client($url, $errno, $errstr, 0, STREAM_CLIENT_CONNECT | STREAM_CLIENT_ASYNC_CONNECT);
+        $contextOpts = array();
+        if ($hostName !== null) {
+            $contextOpts['ssl']['SNI_enabled'] = true;
+            $contextOpts['ssl']['SNI_server_name'] = $hostName;
+        }
+
+        $flags = STREAM_CLIENT_CONNECT | STREAM_CLIENT_ASYNC_CONNECT;
+        $context = stream_context_create($contextOpts);
+        $socket = stream_socket_client($url, $errno, $errstr, 0, $flags, $context);
 
         if (!$socket) {
             return Promise\reject(new \RuntimeException(


### PR DESCRIPTION
In PHP versions <5.6, SNI is not handled correctly unless the context options are set at the time of socket creation. This causes Apache to return 400 responses to HTTPS requests, as the hostname specified in the Host: header does not match the name indicated by SNI. More info on the Apache-specific effect of this can be found [here](https://bugzilla.redhat.com/show_bug.cgi?id=1098711#c7)

This patch addresses the problem by always setting the SNI_server_name for every socket at creation time. Unfortunately the nature of the problem combined with the manner in which connectors work means that this is done to every socket regardless of whether it will be used for SSL or not, but this does not have any adverse effects except the microscopic performance hit of creating a stream context where it is not needed.
