### PR TITLE
Added peer_name to ssl context options

### DIFF
--- a/src/Connector.php
+++ b/src/Connector.php
@@ -36,6 +36,7 @@ class Connector implements ConnectorInterface
         if ($hostName !== null) {
             $contextOpts['ssl']['SNI_enabled'] = true;
             $contextOpts['ssl']['SNI_server_name'] = $hostName;
+            $contextOpts['ssl']['peer_name'] = $hostName;
         }
 
         $flags = STREAM_CLIENT_CONNECT | STREAM_CLIENT_ASYNC_CONNECT;


### PR DESCRIPTION
While trying to connect to a server over HTTPS on PHP5.6 the client expected the CN returned by the server to be the IP address while the server returned it with the hostname resulting in a failed handshake. By adding the `peer_name` to the connection context it uses that instead of the IP address as expected CN.