### PR TITLE
"Fix" minor BC break

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ succeeds or fails.
 ```php
 $connector = new React\SocketClient\Connector($loop, $dns);
 
-$connector->create('www.google.com', 80)->then(function (React\Stream\DuplexStreamInterface $stream) {
+$connector->create('www.google.com', 80)->then(function (React\Stream\Stream $stream) {
     $stream->write('...');
     $stream->close();
 });
@@ -57,7 +57,7 @@ a `Stream` instance that can be used just like any non-encrypted stream.
 ```php
 $secureConnector = new React\SocketClient\SecureConnector($connector, $loop);
 
-$secureConnector->create('www.google.com', 443)->then(function (React\Stream\DuplexStreamInterface $stream) {
+$secureConnector->create('www.google.com', 443)->then(function (React\Stream\Stream $stream) {
     $stream->write("GET / HTTP/1.0\r\nHost: www.google.com\r\n\r\n");
     ...
 });

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ succeeds or fails.
 ```php
 $connector = new React\SocketClient\Connector($loop, $dns);
 
-$connector->create('www.google.com', 80)->then(function (React\Stream\Stream $stream) {
+$connector->create('www.google.com', 80)->then(function (React\Stream\DuplexStreamInterface $stream) {
     $stream->write('...');
     $stream->close();
 });
@@ -57,7 +57,7 @@ a `Stream` instance that can be used just like any non-encrypted stream.
 ```php
 $secureConnector = new React\SocketClient\SecureConnector($connector, $loop);
 
-$secureConnector->create('www.google.com', 443)->then(function (React\Stream\Stream $stream) {
+$secureConnector->create('www.google.com', 443)->then(function (React\Stream\DuplexStreamInterface $stream) {
     $stream->write("GET / HTTP/1.0\r\nHost: www.google.com\r\n\r\n");
     ...
 });

--- a/src/SecureStream.php
+++ b/src/SecureStream.php
@@ -9,12 +9,12 @@ use React\Stream\WritableStreamInterface;
 use React\Stream\Stream;
 use React\Stream\Util;
 
-class SecureStream implements DuplexStreamInterface
+class SecureStream extends Stream implements DuplexStreamInterface
 {
-    use EventEmitterTrait;
-    
+//    use EventEmitterTrait;
+
     public $stream;
-    
+
     public $decorating;
     protected $loop;
 
@@ -35,12 +35,12 @@ class SecureStream implements DuplexStreamInterface
         $stream->on('drain', function() {
             $this->emit('drain', [$this]);
         });
-        
+
         $stream->pause();
-        
+
         $this->resume();
     }
-    
+
     public function handleData($stream)
     {
         $data = stream_get_contents($stream);
@@ -51,7 +51,7 @@ class SecureStream implements DuplexStreamInterface
             $this->end();
         }
     }
-            
+
     public function pause()
     {
         $this->loop->removeReadStream($this->decorating->stream);


### PR DESCRIPTION
Whelp...this fixes the issue...SecureStream extends Stream for the API compatibility but is still completely acting like a decorator. It feels hackey *but* it works with minimal changes and allows the simplest migration path to 0.5. 