### PR TITLE
Explicitly set supported TLS versions for PHP5.6+

### DIFF
--- a/src/StreamEncryption.php
+++ b/src/StreamEncryption.php
@@ -32,8 +32,14 @@ class StreamEncryption
         //  get an empty string back because the buffer indicator could be wrong
         $this->wrapSecure = true;
 
-        if (PHP_VERSION_ID >= 50600) {
-            $this->method = STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT | STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT | STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
+        if (defined('STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT')) {
+            $this->method |= STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT;
+        }
+        if (defined('STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT')) {
+            $this->method |= STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT;
+        }
+        if (defined('STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT')) {
+            $this->method |= STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
         }
     }
 

--- a/src/StreamEncryption.php
+++ b/src/StreamEncryption.php
@@ -31,6 +31,10 @@ class StreamEncryption
         // On versions affected by this bug we need to fread the stream until we
         //  get an empty string back because the buffer indicator could be wrong
         $this->wrapSecure = true;
+
+        if (PHP_VERSION_ID >= 50600) {
+            $this->method = STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT | STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT | STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
+        }
     }
 
     public function enable(Stream $stream)


### PR DESCRIPTION
For `PHP5.6+` with the new `SSL` fixes in that version also changed the way some of the constants work some how forcing `STREAM_CRYPTO_METHOD_TLS_CLIENT` to [`TLS1.0`](https://github.com/php/php-src/blob/a6601cb692fca35b65d6fe0447c63fb6d57708ad/main/streams/php_stream_transport.h#L178). The older [`5.4`](https://github.com/php/php-src/blob/91538759b71d6dccb71cf9c30be6867a9dd67bcd/main/streams/php_stream_transport.h#L172) and [`5.5`](https://github.com/php/php-src/blob/7fb06ce4d388740d79e18b2a15b5ad5020f38a0f/main/streams/php_stream_transport.h#L172) versions of that constant seem to include `TLS1.1` and `TLS1.2`.

I came across this issue when a remote server I was connecting to supported `SSLv2`, `SSLv3`, `TLS1.1`, and `TLS1.2` but not `TLS1.0`. `PHP` was throwing the following error: 

```
stream_socket_enable_crypto(): SSL operation failed with code 1. OpenSSL Error messages: error:1408F10B:SSL routines:SSL3_GET_RECORD:wrong version number
```

By explicitly assigning `1.0`, `1.1`, and `1.2` support to `StreamEncryption::method` for `PHP5.6+` the `SSL` handshake succeeds and the connections follows it's expected course.