### PR TITLE
Use default stream data handler

### DIFF
--- a/src/SecureStream.php
+++ b/src/SecureStream.php
@@ -41,6 +41,18 @@ class SecureStream extends Stream implements DuplexStreamInterface
         $this->resume();
     }
 
+    public function handleData($stream)
+    {
+        $data = fread($stream, $this->bufferSize);
+        $meta = stream_get_meta_data($stream);
+
+        $this->emit('data', [$data, $this]);
+
+        if (!is_resource($stream) || $meta['eof']) {
+            $this->end();
+        }
+    }
+
     public function pause()
     {
         $this->loop->removeReadStream($this->decorating->stream);

--- a/src/SecureStream.php
+++ b/src/SecureStream.php
@@ -41,17 +41,6 @@ class SecureStream extends Stream implements DuplexStreamInterface
         $this->resume();
     }
 
-    public function handleData($stream)
-    {
-        $data = stream_get_contents($stream);
-
-        $this->emit('data', [$data, $this]);
-
-        if (!is_resource($stream) || feof($stream)) {
-            $this->end();
-        }
-    }
-
     public function pause()
     {
         $this->loop->removeReadStream($this->decorating->stream);


### PR DESCRIPTION
This SecureStream data handler uses "stream_get_contents" which will handle data only when connection has been closed. Use "fread" instead which will be used by default in "Stream" Class