### PR TITLE
Add StaticTargetConnector decorator

### DIFF
--- a/src/StaticTargetConnector.php
+++ b/src/StaticTargetConnector.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace React\SocketClient;
+
+use React\SocketClient\ConnectorInterface;
+
+/**
+ * The host/port to connect to is set once during instantiation, the actual
+ * target host/port is then ignored.
+ */
+class StaticTargetConnector implements ConnectorInterface
+{
+    private $connector;
+    private $host;
+    private $port;
+
+    public function __construct(ConnectorInterface $connector, $host, $port)
+    {
+        $this->connector = $connector;
+        $this->host = $host;
+        $this->port = $port;
+    }
+
+    public function create($unusedHost, $unusedPort)
+    {
+        return $this->connector->create($this->host, $this->port);
+    }
+}

--- a/tests/StaticTargetConnectorTest.php
+++ b/tests/StaticTargetConnectorTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace React\Tests\SocketClient;
+
+use React\SocketClient\StaticTargetConnector;
+use React\Promise;
+
+class StaticTargetConnectorTest extends TestCase
+{
+    public function testPassCtorArgsToUnderlyingConnector()
+    {
+        $connector = $this->getMock('React\SocketClient\ConnectorInterface');
+        $connector->expects($this->once())
+                  ->method('create')
+                  ->with($this->equalTo('proxy.example.com'), $this->equalTo(8080))
+                  ->will($this->returnValue(Promise\reject(new \Exception())));
+
+        $static = new StaticTargetConnector($connector, 'proxy.example.com', 8080);
+
+        $promise = $static->create('reactphp.org', 80);
+
+        $promise->then(null, $this->expectCallableOnce());
+    }
+}


### PR DESCRIPTION
Often useful in scenarios where you need a fixed proxy server (https://github.com/reactphp/http-client/issues/44) or communication via Unix domain sockets (https://github.com/reactphp/http-client/issues/46 and #41)
