### PR TITLE
Move SSL/TLS context options to SecureConnector

### DIFF
--- a/src/Connector.php
+++ b/src/Connector.php
@@ -23,25 +23,17 @@ class Connector implements ConnectorInterface
     {
         return $this
             ->resolveHostname($host)
-            ->then(function ($address) use ($port, $host) {
-                return $this->createSocketForAddress($address, $port, $host);
+            ->then(function ($address) use ($port) {
+                return $this->createSocketForAddress($address, $port);
             });
     }
 
-    public function createSocketForAddress($address, $port, $hostName = null)
+    public function createSocketForAddress($address, $port)
     {
         $url = $this->getSocketUrl($address, $port);
 
-        $contextOpts = array();
-        if ($hostName !== null) {
-            $contextOpts['ssl']['SNI_enabled'] = true;
-            $contextOpts['ssl']['SNI_server_name'] = $hostName;
-            $contextOpts['ssl']['peer_name'] = $hostName;
-        }
-
         $flags = STREAM_CLIENT_CONNECT | STREAM_CLIENT_ASYNC_CONNECT;
-        $context = stream_context_create($contextOpts);
-        $socket = stream_socket_client($url, $errno, $errstr, 0, $flags, $context);
+        $socket = stream_socket_client($url, $errno, $errstr, 0, $flags);
 
         if (!$socket) {
             return Promise\reject(new \RuntimeException(

--- a/src/SecureConnector.php
+++ b/src/SecureConnector.php
@@ -18,8 +18,16 @@ class SecureConnector implements ConnectorInterface
 
     public function create($host, $port)
     {
-        return $this->connector->create($host, $port)->then(function (Stream $stream) {
-            // (unencrypted) connection succeeded => try to enable encryption
+        return $this->connector->create($host, $port)->then(function (Stream $stream) use ($host) {
+            // (unencrypted) TCP/IP connection succeeded
+
+            // set required SSL/TLS context options
+            $resource = $stream->stream;
+            stream_context_set_option($resource, 'ssl', 'SNI_enabled', true);
+            stream_context_set_option($resource, 'ssl', 'SNI_server_name', $host);
+            stream_context_set_option($resource, 'ssl', 'peer_name', $host);
+
+            // try to enable encryption
             return $this->streamEncryption->enable($stream)->then(null, function ($error) use ($stream) {
                 // establishing encryption failed => close invalid connection and return error
                 $stream->close();


### PR DESCRIPTION
* TLS endpoints do not have to match connection endpoints (proxy setup)
* More SOLID design, better separation of concerns

This change also makes it easy to introduce additional SSL/TLS context options in the future.
Required for SOCKS proxy (https://github.com/clue/php-socks-react/issues/28) and eventually HTTP proxy (https://github.com/reactphp/http-client/issues/44).