### PR TITLE
[WIP] Additional SSL/TLS context parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ $secureConnector->create('www.google.com', 443)->then(function (React\Stream\Str
 $loop->run();
 ```
 
+The `withContext(array $context)` method can be used to return a
+new `SecureConnector` instance with the given
+[additional TLS/SSL context options](http://php.net/manual/en/context.ssl.php) applied.
+For example, this can be used to disable peer verification in a trusted network:
+ 
+```php
+$secureConnector->withContext(array(
+    'verify_peer' => false,
+    'verify_peer_name' => false,
+))->create('intranet.example.com', 443)->then($callback);
+```
+
 ### Unix domain sockets
 
 Similarly, the `UnixConnector` class can be used to connect to Unix domain socket (UDS)


### PR DESCRIPTION
This is a work-in-progress. The current state is provided in the hope to spark a discussion about this API. This is an alternative approach to #17 in order to achieve a better separation of concerns and to leave the current API unchanged. See also the discussion in #4 for some background.

~~This PR builds on top of #43, so the diff also includes its changes. Look [here](https://github.com/clue-labs/socket-client/compare/secure-context...clue-labs:secure-context-parameters?expand=1) for changes only related to this PR alone.~~ (no longer applies after rebasing)

Fixes #4
Supersedes/closes #17