### PR TITLE
Support Connector without DNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ $dnsConnector->create('www.google.com', 80)->then(function (React\Stream\Stream 
 $loop->run();
 ```
 
+The legacy `Connector` class can be used for backwards-compatiblity reasons.
+It works very much like the newer `DnsConnector` but instead has to be
+set up like this:
+
+```php
+$connector = new React\SocketClient\Connector($loop, $dns);
+
+$connector->create('www.google.com', 80)->then($callback);
+```
+
 ### Async SSL/TLS connections
 
 The `SecureConnector` class decorates a given `Connector` instance by enabling

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace React\SocketClient;
+
+use React\EventLoop\LoopInterface;
+use React\Dns\Resolver\Resolver;
+
+/**
+ * @deprecated Exists for BC only, consider using the newer DnsConnector instead
+ */
+class Connector implements ConnectorInterface
+{
+    private $connector;
+
+    public function __construct(LoopInterface $loop, Resolver $resolver)
+    {
+        $this->connector = new DnsConnector(new TcpConnector($loop), $resolver);
+    }
+
+    public function create($host, $port)
+    {
+        return $this->connector->create($host, $port);
+    }
+}

--- a/src/DnsConnector.php
+++ b/src/DnsConnector.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace React\SocketClient;
+
+use React\EventLoop\LoopInterface;
+use React\Dns\Resolver\Resolver;
+use React\Stream\Stream;
+use React\Promise;
+use React\Promise\Deferred;
+
+class DnsConnector implements ConnectorInterface
+{
+    private $connector;
+    private $resolver;
+
+    public function __construct(ConnectorInterface $connector, Resolver $resolver)
+    {
+        $this->connector = $connector;
+        $this->resolver = $resolver;
+    }
+
+    public function create($host, $port)
+    {
+        $connector = $this->connector;
+
+        return $this
+            ->resolveHostname($host)
+            ->then(function ($address) use ($connector, $port) {
+                return $connector->create($address, $port);
+            });
+    }
+
+    protected function resolveHostname($host)
+    {
+        if (false !== filter_var($host, FILTER_VALIDATE_IP)) {
+            return Promise\resolve($host);
+        }
+
+        return $this->resolver->resolve($host);
+    }
+}

--- a/src/DnsConnector.php
+++ b/src/DnsConnector.php
@@ -30,7 +30,7 @@ class DnsConnector implements ConnectorInterface
             });
     }
 
-    protected function resolveHostname($host)
+    private function resolveHostname($host)
     {
         if (false !== filter_var($host, FILTER_VALIDATE_IP)) {
             return Promise\resolve($host);

--- a/src/TcpConnector.php
+++ b/src/TcpConnector.php
@@ -44,7 +44,7 @@ class TcpConnector implements ConnectorInterface
             ->then(array($this, 'handleConnectedSocket'));
     }
 
-    protected function waitForStreamOnce($stream)
+    private function waitForStreamOnce($stream)
     {
         $deferred = new Deferred();
 
@@ -59,6 +59,7 @@ class TcpConnector implements ConnectorInterface
         return $deferred->promise();
     }
 
+    /** @internal */
     public function checkConnectedSocket($socket)
     {
         // The following hack looks like the only way to
@@ -70,12 +71,13 @@ class TcpConnector implements ConnectorInterface
         return Promise\resolve($socket);
     }
 
+    /** @internal */
     public function handleConnectedSocket($socket)
     {
         return new Stream($socket, $this->loop);
     }
 
-    protected function getSocketUrl($ip, $port)
+    private function getSocketUrl($ip, $port)
     {
         if (strpos($ip, ':') !== false) {
             // enclose IPv6 addresses in square brackets before appending port

--- a/src/TcpConnector.php
+++ b/src/TcpConnector.php
@@ -29,7 +29,7 @@ class TcpConnector implements ConnectorInterface
 
         if (!$socket) {
             return Promise\reject(new \RuntimeException(
-                sprintf("connection to %s:%d failed: %s", $ip, $port, $errstr),
+                sprintf("Connection to %s:%d failed: %s", $ip, $port, $errstr),
                 $errno
             ));
         }

--- a/tests/DnsConnectorTest.php
+++ b/tests/DnsConnectorTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace React\Tests\SocketClient;
+
+use React\SocketClient\DnsConnector;
+use React\Promise;
+
+class DnsConnectorTest extends TestCase
+{
+    private $tcp;
+    private $resolver;
+    private $connector;
+
+    public function setUp()
+    {
+        $this->tcp = $this->getMock('React\SocketClient\ConnectorInterface');
+        $this->resolver = $this->getMockBuilder('React\Dns\Resolver\Resolver')->disableOriginalConstructor()->getMock();
+
+        $this->connector = new DnsConnector($this->tcp, $this->resolver);
+    }
+
+    public function testPassByResolverIfGivenIp()
+    {
+        $this->resolver->expects($this->never())->method('resolve');
+        $this->tcp->expects($this->once())->method('create')->with($this->equalTo('127.0.0.1'), $this->equalTo(80));
+
+        $this->connector->create('127.0.0.1', 80);
+    }
+
+    public function testPassThroughResolverIfGivenHost()
+    {
+        $this->resolver->expects($this->once())->method('resolve')->with($this->equalTo('google.com'))->will($this->returnValue(Promise\resolve('1.2.3.4')));
+        $this->tcp->expects($this->once())->method('create')->with($this->equalTo('1.2.3.4'), $this->equalTo(80));
+
+        $this->connector->create('google.com', 80);
+    }
+
+    public function testSkipConnectionIfDnsFails()
+    {
+        $this->resolver->expects($this->once())->method('resolve')->with($this->equalTo('example.invalid'))->will($this->returnValue(Promise\reject()));
+        $this->tcp->expects($this->never())->method('create');
+
+        $this->connector->create('example.invalid', 80);
+    }
+}

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -8,8 +8,6 @@ use React\Socket\Server;
 use React\SocketClient\Connector;
 use React\SocketClient\SecureConnector;
 use React\Stream\BufferedSink;
-use React\SocketClient\TcpConnector;
-use React\SocketClient\DnsConnector;
 
 class IntegrationTest extends TestCase
 {
@@ -18,11 +16,9 @@ class IntegrationTest extends TestCase
     {
         $loop = new StreamSelectLoop();
 
-        $connector = new TcpConnector($loop);
-
         $factory = new Factory();
         $dns = $factory->create('8.8.8.8', $loop);
-        $connector = new DnsConnector($connector, $dns);
+        $connector = new Connector($loop, $dns);
 
         $connected = false;
         $response = null;
@@ -48,8 +44,6 @@ class IntegrationTest extends TestCase
     {
         $loop = new StreamSelectLoop();
 
-        $connector = new TcpConnector($loop);
-
         $factory = new Factory();
         $dns = $factory->create('8.8.8.8', $loop);
 
@@ -57,7 +51,7 @@ class IntegrationTest extends TestCase
         $response = null;
 
         $secureConnector = new SecureConnector(
-            new DnsConnector($connector, $dns),
+            new Connector($loop, $dns),
             $loop
         );
         $secureConnector->create('google.com', 443)

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -8,6 +8,8 @@ use React\Socket\Server;
 use React\SocketClient\Connector;
 use React\SocketClient\SecureConnector;
 use React\Stream\BufferedSink;
+use React\SocketClient\TcpConnector;
+use React\SocketClient\DnsConnector;
 
 class IntegrationTest extends TestCase
 {
@@ -16,13 +18,15 @@ class IntegrationTest extends TestCase
     {
         $loop = new StreamSelectLoop();
 
+        $connector = new TcpConnector($loop);
+
         $factory = new Factory();
         $dns = $factory->create('8.8.8.8', $loop);
+        $connector = new DnsConnector($connector, $dns);
 
         $connected = false;
         $response = null;
 
-        $connector = new Connector($loop, $dns);
         $connector->create('google.com', 80)
             ->then(function ($conn) use (&$connected) {
                 $connected = true;
@@ -44,6 +48,8 @@ class IntegrationTest extends TestCase
     {
         $loop = new StreamSelectLoop();
 
+        $connector = new TcpConnector($loop);
+
         $factory = new Factory();
         $dns = $factory->create('8.8.8.8', $loop);
 
@@ -51,7 +57,7 @@ class IntegrationTest extends TestCase
         $response = null;
 
         $secureConnector = new SecureConnector(
-            new Connector($loop, $dns),
+            new DnsConnector($connector, $dns),
             $loop
         );
         $secureConnector->create('google.com', 443)

--- a/tests/TcpConnectorTest.php
+++ b/tests/TcpConnectorTest.php
@@ -4,18 +4,16 @@ namespace React\Tests\SocketClient;
 
 use React\EventLoop\StreamSelectLoop;
 use React\Socket\Server;
-use React\SocketClient\Connector;
+use React\SocketClient\TcpConnector;
 
-class ConnectorTest extends TestCase
+class TcpConnectorTest extends TestCase
 {
     /** @test */
     public function connectionToEmptyPortShouldFail()
     {
         $loop = new StreamSelectLoop();
 
-        $dns = $this->createResolverMock();
-
-        $connector = new Connector($loop, $dns);
+        $connector = new TcpConnector($loop);
         $connector->create('127.0.0.1', 9999)
                 ->then($this->expectCallableNever(), $this->expectCallableOnce());
 
@@ -36,9 +34,7 @@ class ConnectorTest extends TestCase
         });
         $server->listen(9999);
 
-        $dns = $this->createResolverMock();
-
-        $connector = new Connector($loop, $dns);
+        $connector = new TcpConnector($loop);
         $connector->create('127.0.0.1', 9999)
                 ->then(function ($stream) use (&$capturedStream) {
                     $capturedStream = $stream;
@@ -55,9 +51,7 @@ class ConnectorTest extends TestCase
     {
         $loop = new StreamSelectLoop();
 
-        $dns = $this->createResolverMock();
-
-        $connector = new Connector($loop, $dns);
+        $connector = new TcpConnector($loop);
         $connector
             ->create('::1', 9999)
             ->then($this->expectCallableNever(), $this->expectCallableOnce());
@@ -77,9 +71,7 @@ class ConnectorTest extends TestCase
         $server->on('connection', array($server, 'shutdown'));
         $server->listen(9999, '::1');
 
-        $dns = $this->createResolverMock();
-
-        $connector = new Connector($loop, $dns);
+        $connector = new TcpConnector($loop);
         $connector
             ->create('::1', 9999)
             ->then(function ($stream) use (&$capturedStream) {
@@ -90,12 +82,5 @@ class ConnectorTest extends TestCase
         $loop->run();
 
         $this->assertInstanceOf('React\Stream\Stream', $capturedStream);
-    }
-
-    private function createResolverMock()
-    {
-        return $this->getMockBuilder('React\Dns\Resolver\Resolver')
-                    ->disableOriginalConstructor()
-                    ->getMock();
     }
 }

--- a/tests/TcpConnectorTest.php
+++ b/tests/TcpConnectorTest.php
@@ -83,4 +83,16 @@ class TcpConnectorTest extends TestCase
 
         $this->assertInstanceOf('React\Stream\Stream', $capturedStream);
     }
+
+    /** @test */
+    public function connectionToHostnameShouldFailImmediately()
+    {
+        $loop = $this->getMock('React\EventLoop\LoopInterface');
+
+        $connector = new TcpConnector($loop);
+        $connector->create('www.google.com', 80)->then(
+            $this->expectCallableNever(),
+            $this->expectCallableOnce()
+        );
+    }
 }


### PR DESCRIPTION
* Split `Connector` into `TcpConnector` and `DnsConnector`
* Legacy `Connector` now acts as a proxy for BC only

~~This PR builds on top of #43, so the diff also includes its changes. Look [here](https://github.com/clue-labs/socket-client/compare/secure-context...clue-labs:resolving?expand=1) for changes only related to this PR alone.~~ (no longer applies after rebasing)

Fixes #12
Supersedes/closes #7