### PR TITLE
Fix error reporting for invalid addresses

### DIFF
--- a/src/TcpConnector.php
+++ b/src/TcpConnector.php
@@ -25,9 +25,9 @@ class TcpConnector implements ConnectorInterface
 
         $url = $this->getSocketUrl($ip, $port);
 
-        $socket = stream_socket_client($url, $errno, $errstr, 0, STREAM_CLIENT_CONNECT | STREAM_CLIENT_ASYNC_CONNECT);
+        $socket = @stream_socket_client($url, $errno, $errstr, 0, STREAM_CLIENT_CONNECT | STREAM_CLIENT_ASYNC_CONNECT);
 
-        if (!$socket) {
+        if (false === $socket) {
             return Promise\reject(new \RuntimeException(
                 sprintf("Connection to %s:%d failed: %s", $ip, $port, $errstr),
                 $errno

--- a/tests/TcpConnectorTest.php
+++ b/tests/TcpConnectorTest.php
@@ -95,4 +95,16 @@ class TcpConnectorTest extends TestCase
             $this->expectCallableOnce()
         );
     }
+
+    /** @test */
+    public function connectionToInvalidAddressShouldFailImmediately()
+    {
+        $loop = $this->getMock('React\EventLoop\LoopInterface');
+
+        $connector = new TcpConnector($loop);
+        $connector->create('255.255.255.255', 12345678)->then(
+            $this->expectCallableNever(),
+            $this->expectCallableOnce()
+        );
+    }
 }


### PR DESCRIPTION
Suppress emitting E_WARNING and test promise is successfully rejected.

~~This PR builds on top of #46, so the diff also includes its changes. Look [here](https://github.com/clue-labs/socket-client/compare/resolving...clue-labs:invalid-address?expand=1) for changes only related to this PR alone.~~ (no longer applies after rebasing)