### PR TITLE
Close stream resource if connection fails

### DIFF
--- a/src/TcpConnector.php
+++ b/src/TcpConnector.php
@@ -65,6 +65,8 @@ class TcpConnector implements ConnectorInterface
         // The following hack looks like the only way to
         // detect connection refused errors with PHP's stream sockets.
         if (false === stream_socket_get_name($socket, true)) {
+            fclose($socket);
+
             return Promise\reject(new ConnectionException('Connection refused'));
         }
 


### PR DESCRIPTION
Currently, if a connection attempt is being rejected, the resulting promise will successfully be rejected. However, the underlying socket resource will not be closed (and is not exposed to the outside).

This is a trivial fix for leaking these resources.

This situation is already covered by our test cases, so it does not include additional tests. We *could* look into counting open socket descriptors, but we'd likely have to resort to using system utilities as PHP does not appear to offer anything related.

~~This PR builds on top of #46, so the diff also includes its changes. Look [here](https://github.com/clue-labs/socket-client/compare/resolving...clue-labs:close?expand=1) for changes only related to this PR alone.~~ (no longer applies after rebasing)