### PR TITLE
Add TimeoutConnector decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,20 @@ $secureConnector = new React\SocketClient\SecureConnector($dnsConnector, $loop, 
 ));
 ```
 
+### Connection timeouts
+
+The `TimeoutConnector` class decorates any given `Connector` instance.
+It provides the same `create()` method, but will automatically reject the
+underlying connection attempt if it takes too long.
+
+```php
+$timeoutConnector = new React\SocketClient\TimeoutConnector($connector, 3.0, $loop);
+
+$timeoutConnector->create('google.com', 80)->then(function (React\Stream\Stream $stream) {
+    // connection succeeded within 3.0 seconds
+});
+```
+
 ### Unix domain sockets
 
 Similarly, the `UnixConnector` class can be used to connect to Unix domain socket (UDS)

--- a/README.md
+++ b/README.md
@@ -137,6 +137,17 @@ $timeoutConnector->create('google.com', 80)->then(function (React\Stream\Stream 
 });
 ```
 
+Pending connection attempts can be cancelled by cancelling its pending promise like so:
+
+```php
+$promise = $timeoutConnector->create($host, $port);
+
+$promise->cancel();
+```
+
+Calling `cancel()` on a pending promise will cancel the underlying connection
+attempt, abort the timer and reject the resulting promise.
+
 ### Unix domain sockets
 
 Similarly, the `UnixConnector` class can be used to connect to Unix domain socket (UDS)

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
         "react/dns": "0.4.*|0.3.*",
         "react/event-loop": "0.4.*|0.3.*",
         "react/stream": "0.4.*|0.3.*",
-        "react/promise": "~2.0|~1.1"
+        "react/promise": "~2.0|~1.1",
+        "react/promise-timer": "~1.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/TimeoutConnector.php
+++ b/src/TimeoutConnector.php
@@ -5,6 +5,9 @@ namespace React\SocketClient;
 use React\SocketClient\ConnectorInterface;
 use React\EventLoop\LoopInterface;
 use React\Promise\Timer;
+use React\Stream\Stream;
+use React\Promise\Promise;
+use React\Promise\CancellablePromiseInterface;
 
 class TimeoutConnector implements ConnectorInterface
 {
@@ -21,6 +24,27 @@ class TimeoutConnector implements ConnectorInterface
 
     public function create($host, $port)
     {
-        return Timer\timeout($this->connector->create($host, $port), $this->timeout, $this->loop);
+        $promise = $this->connector->create($host, $port);
+
+        return Timer\timeout(new Promise(
+            function ($resolve, $reject) use ($promise) {
+                // resolve/reject with result of TCP/IP connection
+                $promise->then($resolve, $reject);
+            },
+            function ($_, $reject) use ($promise) {
+                // cancellation should reject connection attempt
+                $reject(new \RuntimeException('Connection attempt cancelled during connection'));
+
+                // forefully close TCP/IP connection if it completes despite cancellation
+                $promise->then(function (Stream $stream) {
+                    $stream->close();
+                });
+
+                // (try to) cancel pending TCP/IP connection
+                if ($promise instanceof CancellablePromiseInterface) {
+                    $promise->cancel();
+                }
+            }
+        ), $this->timeout, $this->loop);
     }
 }

--- a/src/TimeoutConnector.php
+++ b/src/TimeoutConnector.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace React\SocketClient;
+
+use React\SocketClient\ConnectorInterface;
+use React\EventLoop\LoopInterface;
+use React\Promise\Timer;
+
+class TimeoutConnector implements ConnectorInterface
+{
+    private $connector;
+    private $timeout;
+    private $loop;
+
+    public function __construct(ConnectorInterface $connector, $timeout, LoopInterface $loop)
+    {
+        $this->connector = $connector;
+        $this->timeout = $timeout;
+        $this->loop = $loop;
+    }
+
+    public function create($host, $port)
+    {
+        return Timer\timeout($this->connector->create($host, $port), $this->timeout, $this->loop);
+    }
+}


### PR DESCRIPTION
Uses promise cancellation to cancel pending connection attempts after the timer expired.

~~This means the exposed interface should already work, but the underlying socket resources will not currently be cleaned up in time. As such, it probably makes sense to postpone this until #40 is in. Hence marking this as WIP for now.~~ Edit: See #71

Closes #28, supersedes/closes #10
