### PR TITLE
Add socket and SSL/TLS context options to connectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ $tcpConnector->create('127.0.0.1', 80)->then(function (React\Stream\Stream $stre
 $loop->run();
 ```
 
+You can optionally pass additional
+[socket context options](http://php.net/manual/en/context.socket.php)
+to the constructor like this:
+
+```php
+$tcpConnector = new React\SocketClient\TcpConnector($loop, array(
+    'bindto' => '192.168.0.1:0'
+));
+```
+
 Note that this class only allows you to connect to IP/port combinations.
 If you want to connect to hostname/port combinations, see also the following chapter.
 
@@ -100,6 +110,17 @@ $secureConnector->create('www.google.com', 443)->then(function (React\Stream\Str
 });
 
 $loop->run();
+```
+
+You can optionally pass additional
+[SSL context options](http://php.net/manual/en/context.ssl.php)
+to the constructor like this:
+
+```php
+$secureConnector = new React\SocketClient\SecureConnector($dnsConnector, $loop, array(
+    'verify_peer' => false,
+    'verify_peer_name' => false
+));
 ```
 
 ### Unix domain sockets

--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,8 @@
         "branch-alias": {
             "dev-master": "0.4-dev"
         }
+    },
+    "require-dev": {
+        "clue/block-react": "~1.0"
     }
 }

--- a/src/SecureConnector.php
+++ b/src/SecureConnector.php
@@ -10,11 +10,13 @@ class SecureConnector implements ConnectorInterface
 {
     private $connector;
     private $streamEncryption;
+    private $context;
 
-    public function __construct(ConnectorInterface $connector, LoopInterface $loop)
+    public function __construct(ConnectorInterface $connector, LoopInterface $loop, array $context = array())
     {
         $this->connector = $connector;
         $this->streamEncryption = new StreamEncryption($loop);
+        $this->context = $context;
     }
 
     public function create($host, $port)
@@ -23,14 +25,17 @@ class SecureConnector implements ConnectorInterface
             return Promise\reject(new \BadMethodCallException('Encryption not supported on your platform (HHVM < 3.8?)'));
         }
 
-        return $this->connector->create($host, $port)->then(function (Stream $stream) use ($host) {
+        $context = $this->context + array(
+            'SNI_enabled' => true,
+            'SNI_server_name' => $host,
+            'peer_name' => $host
+        );
+
+        return $this->connector->create($host, $port)->then(function (Stream $stream) use ($context) {
             // (unencrypted) TCP/IP connection succeeded
 
             // set required SSL/TLS context options
-            $resource = $stream->stream;
-            stream_context_set_option($resource, 'ssl', 'SNI_enabled', true);
-            stream_context_set_option($resource, 'ssl', 'SNI_server_name', $host);
-            stream_context_set_option($resource, 'ssl', 'peer_name', $host);
+            stream_context_set_option($stream->stream, array('ssl' => $context));
 
             // try to enable encryption
             return $this->streamEncryption->enable($stream)->then(null, function ($error) use ($stream) {

--- a/src/SecureConnector.php
+++ b/src/SecureConnector.php
@@ -35,7 +35,9 @@ class SecureConnector implements ConnectorInterface
             // (unencrypted) TCP/IP connection succeeded
 
             // set required SSL/TLS context options
-            stream_context_set_option($stream->stream, array('ssl' => $context));
+            foreach ($context as $name => $value) {
+                stream_context_set_option($stream->stream, 'ssl', $name, $value);
+            }
 
             // try to enable encryption
             return $this->streamEncryption->enable($stream)->then(null, function ($error) use ($stream) {

--- a/src/TcpConnector.php
+++ b/src/TcpConnector.php
@@ -11,10 +11,12 @@ use React\Promise\Deferred;
 class TcpConnector implements ConnectorInterface
 {
     private $loop;
+    private $context;
 
-    public function __construct(LoopInterface $loop)
+    public function __construct(LoopInterface $loop, array $context = array())
     {
         $this->loop = $loop;
+        $this->context = $context;
     }
 
     public function create($ip, $port)
@@ -25,7 +27,14 @@ class TcpConnector implements ConnectorInterface
 
         $url = $this->getSocketUrl($ip, $port);
 
-        $socket = @stream_socket_client($url, $errno, $errstr, 0, STREAM_CLIENT_CONNECT | STREAM_CLIENT_ASYNC_CONNECT);
+        $socket = @stream_socket_client(
+            $url,
+            $errno,
+            $errstr,
+            0,
+            STREAM_CLIENT_CONNECT | STREAM_CLIENT_ASYNC_CONNECT,
+            stream_context_create(array('socket' => $this->context))
+        );
 
         if (false === $socket) {
             return Promise\reject(new \RuntimeException(

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -78,6 +78,10 @@ class IntegrationTest extends TestCase
     /** @test */
     public function testSelfSignedRejectsIfVerificationIsEnabled()
     {
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('Not supported on HHVM');
+        }
+
         $loop = new StreamSelectLoop();
 
         $factory = new Factory();
@@ -99,6 +103,10 @@ class IntegrationTest extends TestCase
     /** @test */
     public function testSelfSignedResolvesIfVerificationIsDisabled()
     {
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('Not supported on HHVM');
+        }
+
         $loop = new StreamSelectLoop();
 
         $factory = new Factory();

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -8,6 +8,7 @@ use React\Socket\Server;
 use React\SocketClient\Connector;
 use React\SocketClient\SecureConnector;
 use React\Stream\BufferedSink;
+use Clue\React\Block;
 
 class IntegrationTest extends TestCase
 {
@@ -72,5 +73,46 @@ class IntegrationTest extends TestCase
 
         $this->assertTrue($connected);
         $this->assertRegExp('#^HTTP/1\.0#', $response);
+    }
+
+    /** @test */
+    public function testSelfSignedRejectsIfVerificationIsEnabled()
+    {
+        $loop = new StreamSelectLoop();
+
+        $factory = new Factory();
+        $dns = $factory->create('8.8.8.8', $loop);
+
+
+        $secureConnector = new SecureConnector(
+            new Connector($loop, $dns),
+            $loop,
+            array(
+                'verify_peer' => true
+            )
+        );
+
+        $this->setExpectedException('RuntimeException');
+        Block\await($secureConnector->create('self-signed.badssl.com', 443), $loop);
+    }
+
+    /** @test */
+    public function testSelfSignedResolvesIfVerificationIsDisabled()
+    {
+        $loop = new StreamSelectLoop();
+
+        $factory = new Factory();
+        $dns = $factory->create('8.8.8.8', $loop);
+
+        $secureConnector = new SecureConnector(
+            new Connector($loop, $dns),
+            $loop,
+            array(
+                'verify_peer' => false
+            )
+        );
+
+        $conn = Block\await($secureConnector->create('self-signed.badssl.com', 443), $loop);
+        $conn->close();
     }
 }


### PR DESCRIPTION
This is an alternative approach to #17 and #45 in order to achieve a better separation of concerns and to leave the current API unchanged. See also the discussion in #4 for some background.

~~This PR builds on top of #46, so the diff also includes its changes. Look [here](https://github.com/clue-labs/socket-client/compare/resolving...clue-labs:context?expand=1) for changes only related to this PR alone.~~ (no longer applies after rebasing)

Fixes #4
Supersedes/closes #45
Supersedes/closes #17