### PR TITLE
[RFC] Improve compatibility with legacy versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,11 @@
     "keywords": ["socket"],
     "license": "MIT",
     "require": {
-        "php": ">=5.4.0",
-        "react/dns": "0.4.*",
-        "react/event-loop": "0.4.*",
-        "react/stream": "0.4.*",
-        "react/promise": "~2.0"
+        "php": ">=5.3.0",
+        "react/dns": "0.4.*|0.3.*",
+        "react/event-loop": "0.4.*|0.3.*",
+        "react/stream": "0.4.*|0.3.*",
+        "react/promise": "~2.0|~1.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/SecureConnector.php
+++ b/src/SecureConnector.php
@@ -38,7 +38,8 @@ class SecureConnector implements ConnectorInterface
             );
         }
 
-        return $this->connector->create($host, $port)->then(function (Stream $stream) use ($context) {
+        $encryption = $this->streamEncryption;
+        return $this->connector->create($host, $port)->then(function (Stream $stream) use ($context, $encryption) {
             // (unencrypted) TCP/IP connection succeeded
 
             // set required SSL/TLS context options
@@ -47,7 +48,7 @@ class SecureConnector implements ConnectorInterface
             }
 
             // try to enable encryption
-            return $this->streamEncryption->enable($stream)->then(null, function ($error) use ($stream) {
+            return $encryption->enable($stream)->then(null, function ($error) use ($stream) {
                 // establishing encryption failed => close invalid connection and return error
                 $stream->close();
                 throw $error;

--- a/src/SecureStream.php
+++ b/src/SecureStream.php
@@ -4,12 +4,11 @@ namespace React\SocketClient;
 
 use Evenement\EventEmitterTrait;
 use React\EventLoop\LoopInterface;
-use React\Stream\DuplexStreamInterface;
 use React\Stream\WritableStreamInterface;
 use React\Stream\Stream;
 use React\Stream\Util;
 
-class SecureStream extends Stream implements DuplexStreamInterface
+class SecureStream extends Stream
 {
 //    use EventEmitterTrait;
 
@@ -22,18 +21,19 @@ class SecureStream extends Stream implements DuplexStreamInterface
         $this->stream = $stream->stream;
         $this->decorating = $stream;
         $this->loop = $loop;
+        $that = $this;
 
-        $stream->on('error', function($error) {
-            $this->emit('error', [$error, $this]);
+        $stream->on('error', function($error) use ($that) {
+            $that->emit('error', array($error, $that));
         });
-        $stream->on('end', function() {
-            $this->emit('end', [$this]);
+        $stream->on('end', function() use ($that) {
+            $that->emit('end', array($that));
         });
-        $stream->on('close', function() {
-            $this->emit('close', [$this]);
+        $stream->on('close', function() use ($that) {
+            $that->emit('close', array($that));
         });
-        $stream->on('drain', function() {
-            $this->emit('drain', [$this]);
+        $stream->on('drain', function() use ($that) {
+            $that->emit('drain', array($that));
         });
 
         $stream->pause();
@@ -45,7 +45,7 @@ class SecureStream extends Stream implements DuplexStreamInterface
     {
         $data = stream_get_contents($stream);
 
-        $this->emit('data', [$data, $this]);
+        $this->emit('data', array($data, $this));
 
         if (!is_resource($stream) || feof($stream)) {
             $this->end();
@@ -60,7 +60,7 @@ class SecureStream extends Stream implements DuplexStreamInterface
     public function resume()
     {
         if ($this->isReadable()) {
-            $this->loop->addReadStream($this->decorating->stream, [$this, 'handleData']);
+            $this->loop->addReadStream($this->decorating->stream, array($this, 'handleData'));
         }
     }
 


### PR DESCRIPTION
Because *why not*… :-)

Now more seriously: This project is a low level lib that is used as a building block for quite a few higher level abstractions on top of it. As such, compatibility (even with significantly outdated versions) is a major concern to me.

Note that I'm not suggesting putting *significant amount* of work into this. The patch is already here and, personally, I see little harm in supporting this.

Also note that I'm not suggesting we need to keep support indefinitely. Should this ever turn out to be a burden in the future, e.g. because we actually *require* any new language features or some external lib, then I'm all for dropping support again.