### PR TITLE
PHP 5.6+ uses new SSL/TLS context options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,10 @@ matrix:
     - php: hhvm-nightly
   fast_finish: true
 
-before_script:
-  - composer install --dev --prefer-source
+sudo: false
+
+install:
+  - composer install
 
 script:
   - phpunit --coverage-text

--- a/src/SecureConnector.php
+++ b/src/SecureConnector.php
@@ -18,14 +18,26 @@ class SecureConnector implements ConnectorInterface
 
     public function create($host, $port)
     {
-        return $this->connector->create($host, $port)->then(function (Stream $stream) use ($host) {
+        $context = array(
+            'SNI_enabled' => true,
+            'peer_name' => $host
+        );
+
+        // legacy PHP < 5.6 ignores peer_name and requires legacy context options instead
+        if (PHP_VERSION_ID < 50600) {
+            $context += array(
+                'SNI_server_name' => $host,
+                'CN_match' => $host
+            );
+        }
+
+        return $this->connector->create($host, $port)->then(function (Stream $stream) use ($context) {
             // (unencrypted) TCP/IP connection succeeded
 
             // set required SSL/TLS context options
-            $resource = $stream->stream;
-            stream_context_set_option($resource, 'ssl', 'SNI_enabled', true);
-            stream_context_set_option($resource, 'ssl', 'SNI_server_name', $host);
-            stream_context_set_option($resource, 'ssl', 'peer_name', $host);
+            foreach ($context as $name => $value) {
+                stream_context_set_option($stream->stream, 'ssl', $name, $value);
+            }
 
             // try to enable encryption
             return $this->streamEncryption->enable($stream)->then(null, function ($error) use ($stream) {


### PR DESCRIPTION
This is a backport of #61 in order to make the legacy v0.4 release compatible with PHP 5.6+. No new features will be added otherwise.

This builds on top of the v0.4 branch, which already includes (untagged) #43.

Closes #60.