### PR TITLE
Support Promise cancellation for all connectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,17 @@ $secureConnector->create('www.google.com', 443)->then(function (React\Stream\Str
 $loop->run();
 ```
 
+Pending connection attempts can be cancelled by cancelling its pending promise like so:
+
+```php
+$promise = $secureConnector->create($host, $port);
+
+$promise->cancel();
+```
+
+Calling `cancel()` on a pending promise will cancel the underlying TCP/IP
+connection and/or the SSL/TLS negonation and reject the resulting promise.
+
 You can optionally pass additional
 [SSL context options](http://php.net/manual/en/context.ssl.php)
 to the constructor like this:

--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ $connector->create('/tmp/demo.sock')->then(function (React\Stream\Stream $stream
 $loop->run();
 ```
 
+Connecting to Unix domain sockets is an atomic operation, i.e. its promise will
+settle (either resolve or reject) immediately.
+As such, calling `cancel()` on the resulting promise has no effect.
+
 ## Install
 
 The recommended way to install this library is [through Composer](http://getcomposer.org).

--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ $tcpConnector->create('127.0.0.1', 80)->then(function (React\Stream\Stream $stre
 $loop->run();
 ```
 
+Pending connection attempts can be cancelled by cancelling its pending promise like so:
+
+```php
+$promise = $tcpConnector->create($host, $port);
+
+$promise->cancel();
+```
+
+Calling `cancel()` on a pending promise will close the underlying socket
+resource, thus cancelling the pending TCP/IP connection, and reject the
+resulting promise.
+
 You can optionally pass additional
 [socket context options](http://php.net/manual/en/context.socket.php)
 to the constructor like this:

--- a/README.md
+++ b/README.md
@@ -95,6 +95,17 @@ $dnsConnector->create('www.google.com', 80)->then(function (React\Stream\Stream 
 $loop->run();
 ```
 
+Pending connection attempts can be cancelled by cancelling its pending promise like so:
+
+```php
+$promise = $dnsConnector->create($host, $port);
+
+$promise->cancel();
+```
+
+Calling `cancel()` on a pending promise will cancel the underlying DNS lookup
+and/or the underlying TCP/IP connection and reject the resulting promise.
+
 The legacy `Connector` class can be used for backwards-compatiblity reasons.
 It works very much like the newer `DnsConnector` but instead has to be
 set up like this:

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "react/dns": "0.4.*|0.3.*",
         "react/event-loop": "0.4.*|0.3.*",
         "react/stream": "0.4.*|0.3.*",
-        "react/promise": "~2.0|~1.1"
+        "react/promise": "^2.1 || ^1.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/DnsConnector.php
+++ b/src/DnsConnector.php
@@ -2,11 +2,10 @@
 
 namespace React\SocketClient;
 
-use React\EventLoop\LoopInterface;
 use React\Dns\Resolver\Resolver;
 use React\Stream\Stream;
 use React\Promise;
-use React\Promise\Deferred;
+use React\Promise\CancellablePromiseInterface;
 
 class DnsConnector implements ConnectorInterface
 {
@@ -21,12 +20,12 @@ class DnsConnector implements ConnectorInterface
 
     public function create($host, $port)
     {
-        $connector = $this->connector;
+        $that = $this;
 
         return $this
             ->resolveHostname($host)
-            ->then(function ($address) use ($connector, $port) {
-                return $connector->create($address, $port);
+            ->then(function ($ip) use ($that, $port) {
+                return $that->connect($ip, $port);
             });
     }
 
@@ -36,6 +35,49 @@ class DnsConnector implements ConnectorInterface
             return Promise\resolve($host);
         }
 
-        return $this->resolver->resolve($host);
+        $promise = $this->resolver->resolve($host);
+
+        return new Promise\Promise(
+            function ($resolve, $reject) use ($promise) {
+                // resolve/reject with result of DNS lookup
+                $promise->then($resolve, $reject);
+            },
+            function ($_, $reject) use ($promise) {
+                // cancellation should reject connection attempt
+                $reject(new \RuntimeException('Connection attempt cancelled during DNS lookup'));
+
+                // (try to) cancel pending DNS lookup
+                if ($promise instanceof CancellablePromiseInterface) {
+                    $promise->cancel();
+                }
+            }
+        );
+    }
+
+    /** @internal */
+    public function connect($ip, $port)
+    {
+        $promise = $this->connector->create($ip, $port);
+
+        return new Promise\Promise(
+            function ($resolve, $reject) use ($promise) {
+                // resolve/reject with result of TCP/IP connection
+                $promise->then($resolve, $reject);
+            },
+            function ($_, $reject) use ($promise) {
+                // cancellation should reject connection attempt
+                $reject(new \RuntimeException('Connection attempt cancelled during TCP/IP connection'));
+
+                // forefully close TCP/IP connection if it completes despite cancellation
+                $promise->then(function (Stream $stream) {
+                    $stream->close();
+                });
+
+                // (try to) cancel pending TCP/IP connection
+                if ($promise instanceof CancellablePromiseInterface) {
+                    $promise->cancel();
+                }
+            }
+        );
     }
 }

--- a/tests/DnsConnectorTest.php
+++ b/tests/DnsConnectorTest.php
@@ -22,7 +22,7 @@ class DnsConnectorTest extends TestCase
     public function testPassByResolverIfGivenIp()
     {
         $this->resolver->expects($this->never())->method('resolve');
-        $this->tcp->expects($this->once())->method('create')->with($this->equalTo('127.0.0.1'), $this->equalTo(80));
+        $this->tcp->expects($this->once())->method('create')->with($this->equalTo('127.0.0.1'), $this->equalTo(80))->will($this->returnValue(Promise\reject()));
 
         $this->connector->create('127.0.0.1', 80);
     }
@@ -30,7 +30,7 @@ class DnsConnectorTest extends TestCase
     public function testPassThroughResolverIfGivenHost()
     {
         $this->resolver->expects($this->once())->method('resolve')->with($this->equalTo('google.com'))->will($this->returnValue(Promise\resolve('1.2.3.4')));
-        $this->tcp->expects($this->once())->method('create')->with($this->equalTo('1.2.3.4'), $this->equalTo(80));
+        $this->tcp->expects($this->once())->method('create')->with($this->equalTo('1.2.3.4'), $this->equalTo(80))->will($this->returnValue(Promise\reject()));
 
         $this->connector->create('google.com', 80);
     }
@@ -41,5 +41,47 @@ class DnsConnectorTest extends TestCase
         $this->tcp->expects($this->never())->method('create');
 
         $this->connector->create('example.invalid', 80);
+    }
+
+    public function testCancelDuringDnsCancelsDnsAndDoesNotStartTcpConnection()
+    {
+        $pending = new Promise\Promise(function () { }, $this->expectCallableOnce());
+        $this->resolver->expects($this->once())->method('resolve')->with($this->equalTo('example.com'))->will($this->returnValue($pending));
+        $this->tcp->expects($this->never())->method('resolve');
+
+        $promise = $this->connector->create('example.com', 80);
+        $promise->cancel();
+
+        $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
+    }
+
+    public function testCancelDuringTcpConnectionCancelsTcpConnection()
+    {
+        $pending = new Promise\Promise(function () { }, $this->expectCallableOnce());
+        $this->resolver->expects($this->once())->method('resolve')->with($this->equalTo('example.com'))->will($this->returnValue(Promise\resolve('1.2.3.4')));
+        $this->tcp->expects($this->once())->method('create')->with($this->equalTo('1.2.3.4'), $this->equalTo(80))->will($this->returnValue($pending));
+
+        $promise = $this->connector->create('example.com', 80);
+        $promise->cancel();
+
+        $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
+    }
+
+    public function testCancelClosesStreamIfTcpResolvesDespiteCancellation()
+    {
+        $stream = $this->getMockBuilder('React\Stream\Stream')->disableOriginalConstructor()->setMethods(array('close'))->getMock();
+        $stream->expects($this->once())->method('close');
+
+        $pending = new Promise\Promise(function () { }, function ($resolve) use ($stream) {
+            $resolve($stream);
+        });
+
+        $this->resolver->expects($this->once())->method('resolve')->with($this->equalTo('example.com'))->will($this->returnValue(Promise\resolve('1.2.3.4')));
+        $this->tcp->expects($this->once())->method('create')->with($this->equalTo('1.2.3.4'), $this->equalTo(80))->will($this->returnValue($pending));
+
+        $promise = $this->connector->create('example.com', 80);
+        $promise->cancel();
+
+        $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
     }
 }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -34,8 +34,8 @@ class IntegrationTest extends TestCase
     /** @test */
     public function gettingEncryptedStuffFromGoogleShouldWork()
     {
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped('Not supported on HHVM');
+        if (!function_exists('stream_socket_enable_crypto')) {
+            $this->markTestSkipped('Not supported on your platform (outdated HHVM?)');
         }
 
         $loop = new StreamSelectLoop();
@@ -60,8 +60,8 @@ class IntegrationTest extends TestCase
     /** @test */
     public function testSelfSignedRejectsIfVerificationIsEnabled()
     {
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped('Not supported on HHVM');
+        if (!function_exists('stream_socket_enable_crypto')) {
+            $this->markTestSkipped('Not supported on your platform (outdated HHVM?)');
         }
 
         $loop = new StreamSelectLoop();
@@ -84,8 +84,8 @@ class IntegrationTest extends TestCase
     /** @test */
     public function testSelfSignedResolvesIfVerificationIsDisabled()
     {
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped('Not supported on HHVM');
+        if (!function_exists('stream_socket_enable_crypto')) {
+            $this->markTestSkipped('Not supported on your platform (outdated HHVM?)');
         }
 
         $loop = new StreamSelectLoop();

--- a/tests/SecureConnectorTest.php
+++ b/tests/SecureConnectorTest.php
@@ -13,6 +13,10 @@ class SecureConnectorTest extends TestCase
 
     public function setUp()
     {
+        if (!function_exists('stream_socket_enable_crypto')) {
+            $this->markTestSkipped('Not supported on your platform (outdated HHVM?)');
+        }
+
         $this->loop = $this->getMock('React\EventLoop\LoopInterface');
         $this->tcp = $this->getMock('React\SocketClient\ConnectorInterface');
         $this->connector = new SecureConnector($this->tcp, $this->loop);

--- a/tests/SecureConnectorTest.php
+++ b/tests/SecureConnectorTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace React\Tests\SocketClient;
+
+use React\Promise;
+use React\SocketClient\SecureConnector;
+
+class SecureConnectorTest extends TestCase
+{
+    private $loop;
+    private $tcp;
+    private $connector;
+
+    public function setUp()
+    {
+        $this->loop = $this->getMock('React\EventLoop\LoopInterface');
+        $this->tcp = $this->getMock('React\SocketClient\ConnectorInterface');
+        $this->connector = new SecureConnector($this->tcp, $this->loop);
+    }
+
+    public function testConnectionWillWaitForTcpConnection()
+    {
+        $pending = new Promise\Promise(function () { });
+        $this->tcp->expects($this->once())->method('create')->with($this->equalTo('example.com'), $this->equalTo(80))->will($this->returnValue($pending));
+
+        $promise = $this->connector->create('example.com', 80);
+
+        $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
+    }
+
+    public function testCancelDuringTcpConnectionCancelsTcpConnection()
+    {
+        $pending = new Promise\Promise(function () { }, $this->expectCallableOnce());
+        $this->tcp->expects($this->once())->method('create')->with($this->equalTo('example.com'), $this->equalTo(80))->will($this->returnValue($pending));
+
+        $promise = $this->connector->create('example.com', 80);
+        $promise->cancel();
+
+        $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
+    }
+
+    public function testCancelClosesStreamIfTcpResolvesDespiteCancellation()
+    {
+        $stream = $this->getMockBuilder('React\Stream\Stream')->disableOriginalConstructor()->setMethods(array('close'))->getMock();
+        $stream->expects($this->once())->method('close');
+
+        $pending = new Promise\Promise(function () { }, function ($resolve) use ($stream) {
+            $resolve($stream);
+        });
+
+        $this->tcp->expects($this->once())->method('create')->with($this->equalTo('example.com'), $this->equalTo(80))->will($this->returnValue($pending));
+
+        $promise = $this->connector->create('example.com', 80);
+        $promise->cancel();
+
+        $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
+    }
+}

--- a/tests/SecureIntegrationTest.php
+++ b/tests/SecureIntegrationTest.php
@@ -24,8 +24,8 @@ class SecureIntegrationTest extends TestCase
 
     public function setUp()
     {
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped('Not supported on HHVM');
+        if (!function_exists('stream_socket_enable_crypto')) {
+            $this->markTestSkipped('Not supported on your platform (outdated HHVM?)');
         }
 
         $this->portSecure = getenv('TEST_SECURE');

--- a/tests/TcpConnectorTest.php
+++ b/tests/TcpConnectorTest.php
@@ -97,4 +97,17 @@ class TcpConnectorTest extends TestCase
             $this->expectCallableOnce()
         );
     }
+
+    /** @test */
+    public function cancellingConnectionShouldRejectPromise()
+    {
+        $loop = new StreamSelectLoop();
+        $connector = new TcpConnector($loop);
+
+        $promise = $connector->create('127.0.0.1', 9999);
+        $promise->cancel();
+
+        $this->setExpectedException('RuntimeException', 'Cancelled');
+        Block\await($promise, $loop);
+    }
 }

--- a/tests/TcpConnectorTest.php
+++ b/tests/TcpConnectorTest.php
@@ -104,7 +104,10 @@ class TcpConnectorTest extends TestCase
         $loop = new StreamSelectLoop();
         $connector = new TcpConnector($loop);
 
-        $promise = $connector->create('127.0.0.1', 9999);
+        $server = new Server($loop);
+        $server->listen(0);
+
+        $promise = $connector->create('127.0.0.1', $server->getPort());
         $promise->cancel();
 
         $this->setExpectedException('RuntimeException', 'Cancelled');


### PR DESCRIPTION
We now register a Promise cancellation handler so that the following code actually cleans up the underlying socket resource:

``` php
$promise = $connector->create('reactphp.org', 80);

$promise->cancel();
```

Closes #40 