### PR TITLE
Pass in stream context to prevent CN mismatch on TLS enabled connections

### DIFF
--- a/src/Connector.php
+++ b/src/Connector.php
@@ -33,7 +33,7 @@ class Connector implements ConnectorInterface
         $url = $this->getSocketUrl($address, $port);
 
         $flags = STREAM_CLIENT_CONNECT | STREAM_CLIENT_ASYNC_CONNECT;
-        $socket = stream_socket_client($url, $errno, $errstr, 0, $flags);
+        $socket = stream_socket_client($url, $errno, $errstr, 0, $flags, stream_context_create());
 
         if (!$socket) {
             return Promise\reject(new \RuntimeException(


### PR DESCRIPTION
Ran into an issue while connecting to both `packagist` and `twitter` at the same time. That resulted in the [following error](https://twitter.com/WyriHaximus/status/801170642779439104):
![CN error](https://pbs.twimg.com/media/Cx3XkZUXcAABbzL.jpg)

@DaveRandom jumped on that tweet and came with a repro and work around. This PR applies that workaround to the `0.4` branch, the `master` branch already has this fix in place. But I'll also test and confirm that to be sure.