### PR TITLE
Use `connect($uri)` instead of `create($host, $port)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ $loop = React\EventLoop\Factory::create();
 ### Async TCP/IP connections
 
 The `React\SocketClient\TcpConnector` provides a single promise-based
-`create($ip, $port)` method which resolves as soon as the connection
+`connect($ip, $port)` method which resolves as soon as the connection
 succeeds or fails.
 
 ```php
 $tcpConnector = new React\SocketClient\TcpConnector($loop);
 
-$tcpConnector->create('127.0.0.1', 80)->then(function (React\Stream\Stream $stream) {
+$tcpConnector->connect('127.0.0.1', 80)->then(function (React\Stream\Stream $stream) {
     $stream->write('...');
     $stream->end();
 });
@@ -50,7 +50,7 @@ See also the [first example](examples).
 Pending connection attempts can be cancelled by cancelling its pending promise like so:
 
 ```php
-$promise = $tcpConnector->create($host, $port);
+$promise = $tcpConnector->connect($host, $port);
 
 $promise->cancel();
 ```
@@ -78,18 +78,18 @@ The `DnsConnector` class decorates a given `TcpConnector` instance by first
 looking up the given domain name and then establishing the underlying TCP/IP
 connection to the resolved IP address.
 
-It provides the same promise-based `create($host, $port)` method which resolves with
+It provides the same promise-based `connect($host, $port)` method which resolves with
 a `Stream` instance that can be used just like above.
 
 Make sure to set up your DNS resolver and underlying TCP connector like this:
 
 ```php
 $dnsResolverFactory = new React\Dns\Resolver\Factory();
-$dns = $dnsResolverFactory->createCached('8.8.8.8', $loop);
+$dns = $dnsResolverFactory->connectCached('8.8.8.8', $loop);
 
 $dnsConnector = new React\SocketClient\DnsConnector($tcpConnector, $dns);
 
-$dnsConnector->create('www.google.com', 80)->then(function (React\Stream\Stream $stream) {
+$dnsConnector->connect('www.google.com', 80)->then(function (React\Stream\Stream $stream) {
     $stream->write('...');
     $stream->end();
 });
@@ -102,7 +102,7 @@ See also the [first example](examples).
 Pending connection attempts can be cancelled by cancelling its pending promise like so:
 
 ```php
-$promise = $dnsConnector->create($host, $port);
+$promise = $dnsConnector->connect($host, $port);
 
 $promise->cancel();
 ```
@@ -117,7 +117,7 @@ set up like this:
 ```php
 $connector = new React\SocketClient\Connector($loop, $dns);
 
-$connector->create('www.google.com', 80)->then($callback);
+$connector->connect('www.google.com', 80)->then($callback);
 ```
 
 ### Async SSL/TLS connections
@@ -125,13 +125,13 @@ $connector->create('www.google.com', 80)->then($callback);
 The `SecureConnector` class decorates a given `Connector` instance by enabling
 SSL/TLS encryption as soon as the raw TCP/IP connection succeeds.
 
-It provides the same promise- based `create($host, $port)` method which resolves with
+It provides the same promise- based `connect($host, $port)` method which resolves with
 a `Stream` instance that can be used just like any non-encrypted stream:
 
 ```php
 $secureConnector = new React\SocketClient\SecureConnector($dnsConnector, $loop);
 
-$secureConnector->create('www.google.com', 443)->then(function (React\Stream\Stream $stream) {
+$secureConnector->connect('www.google.com', 443)->then(function (React\Stream\Stream $stream) {
     $stream->write("GET / HTTP/1.0\r\nHost: www.google.com\r\n\r\n");
     ...
 });
@@ -144,7 +144,7 @@ See also the [second example](examples).
 Pending connection attempts can be cancelled by cancelling its pending promise like so:
 
 ```php
-$promise = $secureConnector->create($host, $port);
+$promise = $secureConnector->connect($host, $port);
 
 $promise->cancel();
 ```
@@ -174,13 +174,13 @@ stream resources will use a single, shared *default context* resource otherwise.
 ### Connection timeouts
 
 The `TimeoutConnector` class decorates any given `Connector` instance.
-It provides the same `create()` method, but will automatically reject the
+It provides the same `connect()` method, but will automatically reject the
 underlying connection attempt if it takes too long.
 
 ```php
 $timeoutConnector = new React\SocketClient\TimeoutConnector($connector, 3.0, $loop);
 
-$timeoutConnector->create('google.com', 80)->then(function (React\Stream\Stream $stream) {
+$timeoutConnector->connect('google.com', 80)->then(function (React\Stream\Stream $stream) {
     // connection succeeded within 3.0 seconds
 });
 ```
@@ -190,7 +190,7 @@ See also any of the [examples](examples).
 Pending connection attempts can be cancelled by cancelling its pending promise like so:
 
 ```php
-$promise = $timeoutConnector->create($host, $port);
+$promise = $timeoutConnector->connect($host, $port);
 
 $promise->cancel();
 ```
@@ -206,7 +206,7 @@ paths like this:
 ```php
 $connector = new React\SocketClient\UnixConnector($loop);
 
-$connector->create('/tmp/demo.sock')->then(function (React\Stream\Stream $stream) {
+$connector->connect('/tmp/demo.sock')->then(function (React\Stream\Stream $stream) {
     $stream->write("HELLO\n");
 });
 

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ $loop = React\EventLoop\Factory::create();
 ### Async TCP/IP connections
 
 The `React\SocketClient\TcpConnector` provides a single promise-based
-`connect($ip, $port)` method which resolves as soon as the connection
+`connect($uri)` method which resolves as soon as the connection
 succeeds or fails.
 
 ```php
 $tcpConnector = new React\SocketClient\TcpConnector($loop);
 
-$tcpConnector->connect('127.0.0.1', 80)->then(function (React\Stream\Stream $stream) {
+$tcpConnector->connect('127.0.0.1:80')->then(function (React\Stream\Stream $stream) {
     $stream->write('...');
     $stream->end();
 });
@@ -50,7 +50,7 @@ See also the [first example](examples).
 Pending connection attempts can be cancelled by cancelling its pending promise like so:
 
 ```php
-$promise = $tcpConnector->connect($host, $port);
+$promise = $tcpConnector->connect('127.0.0.1:80');
 
 $promise->cancel();
 ```
@@ -78,7 +78,7 @@ The `DnsConnector` class decorates a given `TcpConnector` instance by first
 looking up the given domain name and then establishing the underlying TCP/IP
 connection to the resolved IP address.
 
-It provides the same promise-based `connect($host, $port)` method which resolves with
+It provides the same promise-based `connect($uri)` method which resolves with
 a `Stream` instance that can be used just like above.
 
 Make sure to set up your DNS resolver and underlying TCP connector like this:
@@ -89,7 +89,7 @@ $dns = $dnsResolverFactory->connectCached('8.8.8.8', $loop);
 
 $dnsConnector = new React\SocketClient\DnsConnector($tcpConnector, $dns);
 
-$dnsConnector->connect('www.google.com', 80)->then(function (React\Stream\Stream $stream) {
+$dnsConnector->connect('www.google.com:80')->then(function (React\Stream\Stream $stream) {
     $stream->write('...');
     $stream->end();
 });
@@ -102,7 +102,7 @@ See also the [first example](examples).
 Pending connection attempts can be cancelled by cancelling its pending promise like so:
 
 ```php
-$promise = $dnsConnector->connect($host, $port);
+$promise = $dnsConnector->connect('www.google.com:80');
 
 $promise->cancel();
 ```
@@ -117,7 +117,7 @@ set up like this:
 ```php
 $connector = new React\SocketClient\Connector($loop, $dns);
 
-$connector->connect('www.google.com', 80)->then($callback);
+$connector->connect('www.google.com:80')->then($callback);
 ```
 
 ### Async SSL/TLS connections
@@ -125,13 +125,13 @@ $connector->connect('www.google.com', 80)->then($callback);
 The `SecureConnector` class decorates a given `Connector` instance by enabling
 SSL/TLS encryption as soon as the raw TCP/IP connection succeeds.
 
-It provides the same promise- based `connect($host, $port)` method which resolves with
+It provides the same promise- based `connect($uri)` method which resolves with
 a `Stream` instance that can be used just like any non-encrypted stream:
 
 ```php
 $secureConnector = new React\SocketClient\SecureConnector($dnsConnector, $loop);
 
-$secureConnector->connect('www.google.com', 443)->then(function (React\Stream\Stream $stream) {
+$secureConnector->connect('www.google.com:443')->then(function (React\Stream\Stream $stream) {
     $stream->write("GET / HTTP/1.0\r\nHost: www.google.com\r\n\r\n");
     ...
 });
@@ -144,7 +144,7 @@ See also the [second example](examples).
 Pending connection attempts can be cancelled by cancelling its pending promise like so:
 
 ```php
-$promise = $secureConnector->connect($host, $port);
+$promise = $secureConnector->connect('www.google.com:443');
 
 $promise->cancel();
 ```
@@ -174,13 +174,13 @@ stream resources will use a single, shared *default context* resource otherwise.
 ### Connection timeouts
 
 The `TimeoutConnector` class decorates any given `Connector` instance.
-It provides the same `connect()` method, but will automatically reject the
+It provides the same `connect($uri)` method, but will automatically reject the
 underlying connection attempt if it takes too long.
 
 ```php
 $timeoutConnector = new React\SocketClient\TimeoutConnector($connector, 3.0, $loop);
 
-$timeoutConnector->connect('google.com', 80)->then(function (React\Stream\Stream $stream) {
+$timeoutConnector->connect('google.com:80')->then(function (React\Stream\Stream $stream) {
     // connection succeeded within 3.0 seconds
 });
 ```
@@ -190,7 +190,7 @@ See also any of the [examples](examples).
 Pending connection attempts can be cancelled by cancelling its pending promise like so:
 
 ```php
-$promise = $timeoutConnector->connect($host, $port);
+$promise = $timeoutConnector->connect('google.com:80');
 
 $promise->cancel();
 ```

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -17,8 +17,8 @@ class Connector implements ConnectorInterface
         $this->connector = new DnsConnector(new TcpConnector($loop), $resolver);
     }
 
-    public function connect($host, $port)
+    public function connect($uri)
     {
-        return $this->connector->connect($host, $port);
+        return $this->connector->connect($uri);
     }
 }

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -17,8 +17,8 @@ class Connector implements ConnectorInterface
         $this->connector = new DnsConnector(new TcpConnector($loop), $resolver);
     }
 
-    public function create($host, $port)
+    public function connect($host, $port)
     {
-        return $this->connector->create($host, $port);
+        return $this->connector->connect($host, $port);
     }
 }

--- a/src/ConnectorInterface.php
+++ b/src/ConnectorInterface.php
@@ -4,5 +4,12 @@ namespace React\SocketClient;
 
 interface ConnectorInterface
 {
-    public function connect($host, $port);
+    /**
+     *
+     *
+     * @param string $uri
+     * @return Promise Returns a Promise<\React\Stream\Stream, \Exception>, i.e.
+     *     it either resolves with a Stream instance or rejects with an Exception.
+     */
+    public function connect($uri);
 }

--- a/src/ConnectorInterface.php
+++ b/src/ConnectorInterface.php
@@ -4,5 +4,5 @@ namespace React\SocketClient;
 
 interface ConnectorInterface
 {
-    public function create($host, $port);
+    public function connect($host, $port);
 }

--- a/src/DnsConnector.php
+++ b/src/DnsConnector.php
@@ -18,14 +18,14 @@ class DnsConnector implements ConnectorInterface
         $this->resolver = $resolver;
     }
 
-    public function create($host, $port)
+    public function connect($host, $port)
     {
         $that = $this;
 
         return $this
             ->resolveHostname($host)
             ->then(function ($ip) use ($that, $port) {
-                return $that->connect($ip, $port);
+                return $that->connectTcp($ip, $port);
             });
     }
 
@@ -55,9 +55,9 @@ class DnsConnector implements ConnectorInterface
     }
 
     /** @internal */
-    public function connect($ip, $port)
+    public function connectTcp($ip, $port)
     {
-        $promise = $this->connector->create($ip, $port);
+        $promise = $this->connector->connect($ip, $port);
 
         return new Promise\Promise(
             function ($resolve, $reject) use ($promise) {

--- a/src/SecureConnector.php
+++ b/src/SecureConnector.php
@@ -20,7 +20,7 @@ class SecureConnector implements ConnectorInterface
         $this->context = $context;
     }
 
-    public function create($host, $port)
+    public function connect($host, $port)
     {
         if (!function_exists('stream_socket_enable_crypto')) {
             return Promise\reject(new \BadMethodCallException('Encryption not supported on your platform (HHVM < 3.8?)'));
@@ -40,7 +40,7 @@ class SecureConnector implements ConnectorInterface
         }
 
         $encryption = $this->streamEncryption;
-        return $this->connect($host, $port)->then(function (Stream $stream) use ($context, $encryption) {
+        return $this->connectTcp($host, $port)->then(function (Stream $stream) use ($context, $encryption) {
             // (unencrypted) TCP/IP connection succeeded
 
             // set required SSL/TLS context options
@@ -57,9 +57,9 @@ class SecureConnector implements ConnectorInterface
         });
     }
 
-    private function connect($host, $port)
+    private function connectTcp($host, $port)
     {
-        $promise = $this->connector->create($host, $port);
+        $promise = $this->connector->connect($host, $port);
 
         return new Promise\Promise(
             function ($resolve, $reject) use ($promise) {

--- a/src/SecureConnector.php
+++ b/src/SecureConnector.php
@@ -26,7 +26,17 @@ class SecureConnector implements ConnectorInterface
             return Promise\reject(new \BadMethodCallException('Encryption not supported on your platform (HHVM < 3.8?)'));
         }
 
-        $host = trim(parse_url('tcp://' . $uri, PHP_URL_HOST), '[]');
+        if (strpos($uri, '://') === false) {
+            $uri = 'tls://' . $uri;
+        }
+
+        $parts = parse_url($uri);
+        if (!$parts || !isset($parts['host']) || $parts['scheme'] !== 'tls') {
+            return Promise\reject(new \InvalidArgumentException('Given URI "' . $uri . '" is invalid'));
+        }
+
+        $uri = str_replace('tls://', '', $uri);
+        $host = trim($parts['host'], '[]');
 
         $context = $this->context + array(
             'SNI_enabled' => true,

--- a/src/TcpConnector.php
+++ b/src/TcpConnector.php
@@ -21,12 +21,16 @@ class TcpConnector implements ConnectorInterface
 
     public function connect($uri)
     {
-        $parts = parse_url('tcp://' . $uri);
-        if (!$parts || !isset($parts['host'], $parts['port'])) {
+        if (strpos($uri, '://') === false) {
+            $uri = 'tcp://' . $uri;
+        }
+
+        $parts = parse_url($uri);
+        if (!$parts || !isset($parts['scheme'], $parts['host'], $parts['port']) || $parts['scheme'] !== 'tcp') {
             return Promise\reject(new \InvalidArgumentException('Given URI "' . $uri . '" is invalid'));
         }
-        $ip = trim($parts['host'], '[]');
 
+        $ip = trim($parts['host'], '[]');
         if (false === filter_var($ip, FILTER_VALIDATE_IP)) {
             return Promise\reject(new \InvalidArgumentException('Given URI "' . $ip . '" does not contain a valid host IP'));
         }

--- a/src/TcpConnector.php
+++ b/src/TcpConnector.php
@@ -19,7 +19,7 @@ class TcpConnector implements ConnectorInterface
         $this->context = $context;
     }
 
-    public function create($ip, $port)
+    public function connect($ip, $port)
     {
         if (false === filter_var($ip, FILTER_VALIDATE_IP)) {
             return Promise\reject(new \InvalidArgumentException('Given parameter "' . $ip . '" is not a valid IP'));

--- a/src/TimeoutConnector.php
+++ b/src/TimeoutConnector.php
@@ -22,9 +22,9 @@ class TimeoutConnector implements ConnectorInterface
         $this->loop = $loop;
     }
 
-    public function connect($host, $port)
+    public function connect($uri)
     {
-        $promise = $this->connector->connect($host, $port);
+        $promise = $this->connector->connect($uri);
 
         return Timer\timeout(new Promise(
             function ($resolve, $reject) use ($promise) {

--- a/src/TimeoutConnector.php
+++ b/src/TimeoutConnector.php
@@ -22,9 +22,9 @@ class TimeoutConnector implements ConnectorInterface
         $this->loop = $loop;
     }
 
-    public function create($host, $port)
+    public function connect($host, $port)
     {
-        $promise = $this->connector->create($host, $port);
+        $promise = $this->connector->connect($host, $port);
 
         return Timer\timeout(new Promise(
             function ($resolve, $reject) use ($promise) {

--- a/src/UnixConnector.php
+++ b/src/UnixConnector.php
@@ -25,7 +25,13 @@ class UnixConnector implements ConnectorInterface
 
     public function connect($path)
     {
-        $resource = @stream_socket_client('unix://' . $path, $errno, $errstr, 1.0);
+        if (strpos($path, '://') === false) {
+            $path = 'unix://' . $path;
+        } elseif (substr($path, 0, 7) !== 'unix://') {
+            return Promise\reject(new \InvalidArgumentException('Given URI "' . $path . '" is invalid'));
+        }
+
+        $resource = @stream_socket_client($path, $errno, $errstr, 1.0);
 
         if (!$resource) {
             return Promise\reject(new RuntimeException('Unable to connect to unix domain socket "' . $path . '": ' . $errstr, $errno));

--- a/src/UnixConnector.php
+++ b/src/UnixConnector.php
@@ -23,7 +23,7 @@ class UnixConnector implements ConnectorInterface
         $this->loop = $loop;
     }
 
-    public function connect($path, $unusedPort = 0)
+    public function connect($path)
     {
         $resource = @stream_socket_client('unix://' . $path, $errno, $errstr, 1.0);
 

--- a/src/UnixConnector.php
+++ b/src/UnixConnector.php
@@ -23,7 +23,7 @@ class UnixConnector implements ConnectorInterface
         $this->loop = $loop;
     }
 
-    public function create($path, $unusedPort = 0)
+    public function connect($path, $unusedPort = 0)
     {
         $resource = @stream_socket_client('unix://' . $path, $errno, $errstr, 1.0);
 

--- a/tests/DnsConnectorTest.php
+++ b/tests/DnsConnectorTest.php
@@ -22,17 +22,17 @@ class DnsConnectorTest extends TestCase
     public function testPassByResolverIfGivenIp()
     {
         $this->resolver->expects($this->never())->method('resolve');
-        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('127.0.0.1'), $this->equalTo(80))->will($this->returnValue(Promise\reject()));
+        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('127.0.0.1:80'))->will($this->returnValue(Promise\reject()));
 
-        $this->connector->connect('127.0.0.1', 80);
+        $this->connector->connect('127.0.0.1:80');
     }
 
     public function testPassThroughResolverIfGivenHost()
     {
         $this->resolver->expects($this->once())->method('resolve')->with($this->equalTo('google.com'))->will($this->returnValue(Promise\resolve('1.2.3.4')));
-        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('1.2.3.4'), $this->equalTo(80))->will($this->returnValue(Promise\reject()));
+        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('1.2.3.4:80'))->will($this->returnValue(Promise\reject()));
 
-        $this->connector->connect('google.com', 80);
+        $this->connector->connect('google.com:80');
     }
 
     public function testSkipConnectionIfDnsFails()
@@ -40,7 +40,7 @@ class DnsConnectorTest extends TestCase
         $this->resolver->expects($this->once())->method('resolve')->with($this->equalTo('example.invalid'))->will($this->returnValue(Promise\reject()));
         $this->tcp->expects($this->never())->method('connect');
 
-        $this->connector->connect('example.invalid', 80);
+        $this->connector->connect('example.invalid:80');
     }
 
     public function testCancelDuringDnsCancelsDnsAndDoesNotStartTcpConnection()
@@ -49,7 +49,7 @@ class DnsConnectorTest extends TestCase
         $this->resolver->expects($this->once())->method('resolve')->with($this->equalTo('example.com'))->will($this->returnValue($pending));
         $this->tcp->expects($this->never())->method('resolve');
 
-        $promise = $this->connector->connect('example.com', 80);
+        $promise = $this->connector->connect('example.com:80');
         $promise->cancel();
 
         $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
@@ -59,9 +59,9 @@ class DnsConnectorTest extends TestCase
     {
         $pending = new Promise\Promise(function () { }, $this->expectCallableOnce());
         $this->resolver->expects($this->once())->method('resolve')->with($this->equalTo('example.com'))->will($this->returnValue(Promise\resolve('1.2.3.4')));
-        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('1.2.3.4'), $this->equalTo(80))->will($this->returnValue($pending));
+        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('1.2.3.4:80'))->will($this->returnValue($pending));
 
-        $promise = $this->connector->connect('example.com', 80);
+        $promise = $this->connector->connect('example.com:80');
         $promise->cancel();
 
         $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
@@ -77,9 +77,9 @@ class DnsConnectorTest extends TestCase
         });
 
         $this->resolver->expects($this->once())->method('resolve')->with($this->equalTo('example.com'))->will($this->returnValue(Promise\resolve('1.2.3.4')));
-        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('1.2.3.4'), $this->equalTo(80))->will($this->returnValue($pending));
+        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('1.2.3.4:80'))->will($this->returnValue($pending));
 
-        $promise = $this->connector->connect('example.com', 80);
+        $promise = $this->connector->connect('example.com:80');
         $promise->cancel();
 
         $promise->then($this->expectCallableNever(), $this->expectCallableOnce());

--- a/tests/DnsConnectorTest.php
+++ b/tests/DnsConnectorTest.php
@@ -22,25 +22,25 @@ class DnsConnectorTest extends TestCase
     public function testPassByResolverIfGivenIp()
     {
         $this->resolver->expects($this->never())->method('resolve');
-        $this->tcp->expects($this->once())->method('create')->with($this->equalTo('127.0.0.1'), $this->equalTo(80))->will($this->returnValue(Promise\reject()));
+        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('127.0.0.1'), $this->equalTo(80))->will($this->returnValue(Promise\reject()));
 
-        $this->connector->create('127.0.0.1', 80);
+        $this->connector->connect('127.0.0.1', 80);
     }
 
     public function testPassThroughResolverIfGivenHost()
     {
         $this->resolver->expects($this->once())->method('resolve')->with($this->equalTo('google.com'))->will($this->returnValue(Promise\resolve('1.2.3.4')));
-        $this->tcp->expects($this->once())->method('create')->with($this->equalTo('1.2.3.4'), $this->equalTo(80))->will($this->returnValue(Promise\reject()));
+        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('1.2.3.4'), $this->equalTo(80))->will($this->returnValue(Promise\reject()));
 
-        $this->connector->create('google.com', 80);
+        $this->connector->connect('google.com', 80);
     }
 
     public function testSkipConnectionIfDnsFails()
     {
         $this->resolver->expects($this->once())->method('resolve')->with($this->equalTo('example.invalid'))->will($this->returnValue(Promise\reject()));
-        $this->tcp->expects($this->never())->method('create');
+        $this->tcp->expects($this->never())->method('connect');
 
-        $this->connector->create('example.invalid', 80);
+        $this->connector->connect('example.invalid', 80);
     }
 
     public function testCancelDuringDnsCancelsDnsAndDoesNotStartTcpConnection()
@@ -49,7 +49,7 @@ class DnsConnectorTest extends TestCase
         $this->resolver->expects($this->once())->method('resolve')->with($this->equalTo('example.com'))->will($this->returnValue($pending));
         $this->tcp->expects($this->never())->method('resolve');
 
-        $promise = $this->connector->create('example.com', 80);
+        $promise = $this->connector->connect('example.com', 80);
         $promise->cancel();
 
         $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
@@ -59,9 +59,9 @@ class DnsConnectorTest extends TestCase
     {
         $pending = new Promise\Promise(function () { }, $this->expectCallableOnce());
         $this->resolver->expects($this->once())->method('resolve')->with($this->equalTo('example.com'))->will($this->returnValue(Promise\resolve('1.2.3.4')));
-        $this->tcp->expects($this->once())->method('create')->with($this->equalTo('1.2.3.4'), $this->equalTo(80))->will($this->returnValue($pending));
+        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('1.2.3.4'), $this->equalTo(80))->will($this->returnValue($pending));
 
-        $promise = $this->connector->create('example.com', 80);
+        $promise = $this->connector->connect('example.com', 80);
         $promise->cancel();
 
         $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
@@ -77,9 +77,9 @@ class DnsConnectorTest extends TestCase
         });
 
         $this->resolver->expects($this->once())->method('resolve')->with($this->equalTo('example.com'))->will($this->returnValue(Promise\resolve('1.2.3.4')));
-        $this->tcp->expects($this->once())->method('create')->with($this->equalTo('1.2.3.4'), $this->equalTo(80))->will($this->returnValue($pending));
+        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('1.2.3.4'), $this->equalTo(80))->will($this->returnValue($pending));
 
-        $promise = $this->connector->create('example.com', 80);
+        $promise = $this->connector->connect('example.com', 80);
         $promise->cancel();
 
         $promise->then($this->expectCallableNever(), $this->expectCallableOnce());

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -24,7 +24,7 @@ class IntegrationTest extends TestCase
         $dns = $factory->create('8.8.8.8', $loop);
         $connector = new Connector($loop, $dns);
 
-        $conn = Block\await($connector->create('google.com', 80), $loop);
+        $conn = Block\await($connector->connect('google.com', 80), $loop);
 
         $conn->write("GET / HTTP/1.0\r\n\r\n");
 
@@ -50,7 +50,7 @@ class IntegrationTest extends TestCase
             $loop
         );
 
-        $conn = Block\await($secureConnector->create('google.com', 443), $loop);
+        $conn = Block\await($secureConnector->connect('google.com', 443), $loop);
 
         $conn->write("GET / HTTP/1.0\r\n\r\n");
 
@@ -80,7 +80,7 @@ class IntegrationTest extends TestCase
         );
 
         $this->setExpectedException('RuntimeException');
-        Block\await($secureConnector->create('self-signed.badssl.com', 443), $loop, self::TIMEOUT);
+        Block\await($secureConnector->connect('self-signed.badssl.com', 443), $loop, self::TIMEOUT);
     }
 
     /** @test */
@@ -103,7 +103,7 @@ class IntegrationTest extends TestCase
             )
         );
 
-        $conn = Block\await($secureConnector->create('self-signed.badssl.com', 443), $loop, self::TIMEOUT);
+        $conn = Block\await($secureConnector->connect('self-signed.badssl.com', 443), $loop, self::TIMEOUT);
         $conn->close();
     }
 
@@ -112,7 +112,7 @@ class IntegrationTest extends TestCase
         $loop = new StreamSelectLoop();
 
         $connector = new TcpConnector($loop);
-        $pending = $connector->create('8.8.8.8', 80);
+        $pending = $connector->connect('8.8.8.8', 80);
 
         $loop->addTimer(0.001, function () use ($pending) {
             $pending->cancel();

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -24,7 +24,7 @@ class IntegrationTest extends TestCase
         $dns = $factory->create('8.8.8.8', $loop);
         $connector = new Connector($loop, $dns);
 
-        $conn = Block\await($connector->connect('google.com', 80), $loop);
+        $conn = Block\await($connector->connect('google.com:80'), $loop);
 
         $conn->write("GET / HTTP/1.0\r\n\r\n");
 
@@ -50,7 +50,7 @@ class IntegrationTest extends TestCase
             $loop
         );
 
-        $conn = Block\await($secureConnector->connect('google.com', 443), $loop);
+        $conn = Block\await($secureConnector->connect('google.com:443'), $loop);
 
         $conn->write("GET / HTTP/1.0\r\n\r\n");
 
@@ -80,7 +80,7 @@ class IntegrationTest extends TestCase
         );
 
         $this->setExpectedException('RuntimeException');
-        Block\await($secureConnector->connect('self-signed.badssl.com', 443), $loop, self::TIMEOUT);
+        Block\await($secureConnector->connect('self-signed.badssl.com:443'), $loop, self::TIMEOUT);
     }
 
     /** @test */
@@ -103,7 +103,7 @@ class IntegrationTest extends TestCase
             )
         );
 
-        $conn = Block\await($secureConnector->connect('self-signed.badssl.com', 443), $loop, self::TIMEOUT);
+        $conn = Block\await($secureConnector->connect('self-signed.badssl.com:443'), $loop, self::TIMEOUT);
         $conn->close();
     }
 
@@ -112,7 +112,7 @@ class IntegrationTest extends TestCase
         $loop = new StreamSelectLoop();
 
         $connector = new TcpConnector($loop);
-        $pending = $connector->connect('8.8.8.8', 80);
+        $pending = $connector->connect('8.8.8.8:80');
 
         $loop->addTimer(0.001, function () use ($pending) {
             $pending->cancel();

--- a/tests/SecureConnectorTest.php
+++ b/tests/SecureConnectorTest.php
@@ -25,9 +25,9 @@ class SecureConnectorTest extends TestCase
     public function testConnectionWillWaitForTcpConnection()
     {
         $pending = new Promise\Promise(function () { });
-        $this->tcp->expects($this->once())->method('create')->with($this->equalTo('example.com'), $this->equalTo(80))->will($this->returnValue($pending));
+        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('example.com'), $this->equalTo(80))->will($this->returnValue($pending));
 
-        $promise = $this->connector->create('example.com', 80);
+        $promise = $this->connector->connect('example.com', 80);
 
         $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
     }
@@ -35,9 +35,9 @@ class SecureConnectorTest extends TestCase
     public function testCancelDuringTcpConnectionCancelsTcpConnection()
     {
         $pending = new Promise\Promise(function () { }, $this->expectCallableOnce());
-        $this->tcp->expects($this->once())->method('create')->with($this->equalTo('example.com'), $this->equalTo(80))->will($this->returnValue($pending));
+        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('example.com'), $this->equalTo(80))->will($this->returnValue($pending));
 
-        $promise = $this->connector->create('example.com', 80);
+        $promise = $this->connector->connect('example.com', 80);
         $promise->cancel();
 
         $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
@@ -52,9 +52,9 @@ class SecureConnectorTest extends TestCase
             $resolve($stream);
         });
 
-        $this->tcp->expects($this->once())->method('create')->with($this->equalTo('example.com'), $this->equalTo(80))->will($this->returnValue($pending));
+        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('example.com'), $this->equalTo(80))->will($this->returnValue($pending));
 
-        $promise = $this->connector->create('example.com', 80);
+        $promise = $this->connector->connect('example.com', 80);
         $promise->cancel();
 
         $promise->then($this->expectCallableNever(), $this->expectCallableOnce());

--- a/tests/SecureConnectorTest.php
+++ b/tests/SecureConnectorTest.php
@@ -25,9 +25,9 @@ class SecureConnectorTest extends TestCase
     public function testConnectionWillWaitForTcpConnection()
     {
         $pending = new Promise\Promise(function () { });
-        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('example.com'), $this->equalTo(80))->will($this->returnValue($pending));
+        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('example.com:80'))->will($this->returnValue($pending));
 
-        $promise = $this->connector->connect('example.com', 80);
+        $promise = $this->connector->connect('example.com:80');
 
         $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
     }
@@ -35,9 +35,9 @@ class SecureConnectorTest extends TestCase
     public function testCancelDuringTcpConnectionCancelsTcpConnection()
     {
         $pending = new Promise\Promise(function () { }, $this->expectCallableOnce());
-        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('example.com'), $this->equalTo(80))->will($this->returnValue($pending));
+        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('example.com:80'))->will($this->returnValue($pending));
 
-        $promise = $this->connector->connect('example.com', 80);
+        $promise = $this->connector->connect('example.com:80');
         $promise->cancel();
 
         $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
@@ -52,9 +52,9 @@ class SecureConnectorTest extends TestCase
             $resolve($stream);
         });
 
-        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('example.com'), $this->equalTo(80))->will($this->returnValue($pending));
+        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('example.com:80'))->will($this->returnValue($pending));
 
-        $promise = $this->connector->connect('example.com', 80);
+        $promise = $this->connector->connect('example.com:80');
         $promise->cancel();
 
         $promise->then($this->expectCallableNever(), $this->expectCallableOnce());

--- a/tests/SecureConnectorTest.php
+++ b/tests/SecureConnectorTest.php
@@ -32,6 +32,23 @@ class SecureConnectorTest extends TestCase
         $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
     }
 
+    public function testConnectionWithCompleteUriWillBePassedThroughExpectForScheme()
+    {
+        $pending = new Promise\Promise(function () { });
+        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('example.com:80/path?query#fragment'))->will($this->returnValue($pending));
+
+        $this->connector->connect('tls://example.com:80/path?query#fragment');
+    }
+
+    public function testConnectionToInvalidSchemeWillReject()
+    {
+        $this->tcp->expects($this->never())->method('connect');
+
+        $promise = $this->connector->connect('tcp://example.com:80');
+
+        $promise->then(null, $this->expectCallableOnce());
+    }
+
     public function testCancelDuringTcpConnectionCancelsTcpConnection()
     {
         $pending = new Promise\Promise(function () { }, $this->expectCallableOnce());

--- a/tests/SecureIntegrationTest.php
+++ b/tests/SecureIntegrationTest.php
@@ -53,7 +53,7 @@ class SecureIntegrationTest extends TestCase
 
     public function testConnectToServer()
     {
-        $client = Block\await($this->connector->connect('127.0.0.1', $this->portSecure), $this->loop, self::TIMEOUT);
+        $client = Block\await($this->connector->connect('127.0.0.1:' . $this->portSecure), $this->loop, self::TIMEOUT);
         /* @var $client Stream */
 
         $client->close();
@@ -63,7 +63,7 @@ class SecureIntegrationTest extends TestCase
     {
         $promiseServer = $this->createPromiseForEvent($this->server, 'connection', $this->expectCallableOnce());
 
-        $promiseClient = $this->connector->connect('127.0.0.1', $this->portSecure);
+        $promiseClient = $this->connector->connect('127.0.0.1:' . $this->portSecure);
 
         list($_, $client) = Block\awaitAll(array($promiseServer, $promiseClient), $this->loop, self::TIMEOUT);
         /* @var $client Stream */
@@ -81,7 +81,7 @@ class SecureIntegrationTest extends TestCase
             });
         });
 
-        $client = Block\await($this->connector->connect('127.0.0.1', $this->portSecure), $this->loop, self::TIMEOUT);
+        $client = Block\await($this->connector->connect('127.0.0.1:' . $this->portSecure), $this->loop, self::TIMEOUT);
         /* @var $client Stream */
 
         $client->write('hello');
@@ -107,7 +107,7 @@ class SecureIntegrationTest extends TestCase
             });
         });
 
-        $client = Block\await($this->connector->connect('127.0.0.1', $this->portSecure), $this->loop, self::TIMEOUT);
+        $client = Block\await($this->connector->connect('127.0.0.1:' . $this->portSecure), $this->loop, self::TIMEOUT);
         /* @var $client Stream */
 
         $data = str_repeat('a', 200000);
@@ -128,7 +128,7 @@ class SecureIntegrationTest extends TestCase
             });
         });
 
-        $client = Block\await($this->connector->connect('127.0.0.1', $this->portSecure), $this->loop, self::TIMEOUT);
+        $client = Block\await($this->connector->connect('127.0.0.1:' . $this->portSecure), $this->loop, self::TIMEOUT);
         /* @var $client Stream */
 
         $data = str_repeat('d', 200000);
@@ -148,7 +148,7 @@ class SecureIntegrationTest extends TestCase
             $peer->write('hello');
         });
 
-        $client = Block\await($this->connector->connect('127.0.0.1', $this->portSecure), $this->loop, self::TIMEOUT);
+        $client = Block\await($this->connector->connect('127.0.0.1:' . $this->portSecure), $this->loop, self::TIMEOUT);
         /* @var $client Stream */
 
         // await client to report one "data" event
@@ -165,7 +165,7 @@ class SecureIntegrationTest extends TestCase
             $peer->end($data);
         });
 
-        $client = Block\await($this->connector->connect('127.0.0.1', $this->portSecure), $this->loop, self::TIMEOUT);
+        $client = Block\await($this->connector->connect('127.0.0.1:' . $this->portSecure), $this->loop, self::TIMEOUT);
         /* @var $client Stream */
 
         // await data from client until it closes
@@ -181,7 +181,7 @@ class SecureIntegrationTest extends TestCase
             $peer->write($data);
         });
 
-        $client = Block\await($this->connector->connect('127.0.0.1', $this->portSecure), $this->loop);
+        $client = Block\await($this->connector->connect('127.0.0.1:' . $this->portSecure), $this->loop);
         /* @var $client Stream */
 
         // buffer incoming data for 0.1s (should be plenty of time)

--- a/tests/SecureIntegrationTest.php
+++ b/tests/SecureIntegrationTest.php
@@ -53,7 +53,7 @@ class SecureIntegrationTest extends TestCase
 
     public function testConnectToServer()
     {
-        $client = Block\await($this->connector->create('127.0.0.1', $this->portSecure), $this->loop, self::TIMEOUT);
+        $client = Block\await($this->connector->connect('127.0.0.1', $this->portSecure), $this->loop, self::TIMEOUT);
         /* @var $client Stream */
 
         $client->close();
@@ -63,7 +63,7 @@ class SecureIntegrationTest extends TestCase
     {
         $promiseServer = $this->createPromiseForEvent($this->server, 'connection', $this->expectCallableOnce());
 
-        $promiseClient = $this->connector->create('127.0.0.1', $this->portSecure);
+        $promiseClient = $this->connector->connect('127.0.0.1', $this->portSecure);
 
         list($_, $client) = Block\awaitAll(array($promiseServer, $promiseClient), $this->loop, self::TIMEOUT);
         /* @var $client Stream */
@@ -81,7 +81,7 @@ class SecureIntegrationTest extends TestCase
             });
         });
 
-        $client = Block\await($this->connector->create('127.0.0.1', $this->portSecure), $this->loop, self::TIMEOUT);
+        $client = Block\await($this->connector->connect('127.0.0.1', $this->portSecure), $this->loop, self::TIMEOUT);
         /* @var $client Stream */
 
         $client->write('hello');
@@ -107,7 +107,7 @@ class SecureIntegrationTest extends TestCase
             });
         });
 
-        $client = Block\await($this->connector->create('127.0.0.1', $this->portSecure), $this->loop, self::TIMEOUT);
+        $client = Block\await($this->connector->connect('127.0.0.1', $this->portSecure), $this->loop, self::TIMEOUT);
         /* @var $client Stream */
 
         $data = str_repeat('a', 200000);
@@ -128,7 +128,7 @@ class SecureIntegrationTest extends TestCase
             });
         });
 
-        $client = Block\await($this->connector->create('127.0.0.1', $this->portSecure), $this->loop, self::TIMEOUT);
+        $client = Block\await($this->connector->connect('127.0.0.1', $this->portSecure), $this->loop, self::TIMEOUT);
         /* @var $client Stream */
 
         $data = str_repeat('d', 200000);
@@ -148,7 +148,7 @@ class SecureIntegrationTest extends TestCase
             $peer->write('hello');
         });
 
-        $client = Block\await($this->connector->create('127.0.0.1', $this->portSecure), $this->loop, self::TIMEOUT);
+        $client = Block\await($this->connector->connect('127.0.0.1', $this->portSecure), $this->loop, self::TIMEOUT);
         /* @var $client Stream */
 
         // await client to report one "data" event
@@ -165,7 +165,7 @@ class SecureIntegrationTest extends TestCase
             $peer->end($data);
         });
 
-        $client = Block\await($this->connector->create('127.0.0.1', $this->portSecure), $this->loop, self::TIMEOUT);
+        $client = Block\await($this->connector->connect('127.0.0.1', $this->portSecure), $this->loop, self::TIMEOUT);
         /* @var $client Stream */
 
         // await data from client until it closes
@@ -181,7 +181,7 @@ class SecureIntegrationTest extends TestCase
             $peer->write($data);
         });
 
-        $client = Block\await($this->connector->create('127.0.0.1', $this->portSecure), $this->loop);
+        $client = Block\await($this->connector->connect('127.0.0.1', $this->portSecure), $this->loop);
         /* @var $client Stream */
 
         // buffer incoming data for 0.1s (should be plenty of time)

--- a/tests/TcpConnectorTest.php
+++ b/tests/TcpConnectorTest.php
@@ -17,7 +17,7 @@ class TcpConnectorTest extends TestCase
         $loop = new StreamSelectLoop();
 
         $connector = new TcpConnector($loop);
-        $connector->connect('127.0.0.1', 9999)
+        $connector->connect('127.0.0.1:9999')
                 ->then($this->expectCallableNever(), $this->expectCallableOnce());
 
         $loop->run();
@@ -37,7 +37,7 @@ class TcpConnectorTest extends TestCase
 
         $connector = new TcpConnector($loop);
 
-        $stream = Block\await($connector->connect('127.0.0.1', 9999), $loop, self::TIMEOUT);
+        $stream = Block\await($connector->connect('127.0.0.1:9999'), $loop, self::TIMEOUT);
 
         $this->assertInstanceOf('React\Stream\Stream', $stream);
 
@@ -51,7 +51,7 @@ class TcpConnectorTest extends TestCase
 
         $connector = new TcpConnector($loop);
         $connector
-            ->connect('::1', 9999)
+            ->connect('[::1]:9999')
             ->then($this->expectCallableNever(), $this->expectCallableOnce());
 
         $loop->run();
@@ -69,7 +69,7 @@ class TcpConnectorTest extends TestCase
 
         $connector = new TcpConnector($loop);
 
-        $stream = Block\await($connector->connect('::1', 9999), $loop, self::TIMEOUT);
+        $stream = Block\await($connector->connect('[::1]:9999'), $loop, self::TIMEOUT);
 
         $this->assertInstanceOf('React\Stream\Stream', $stream);
 
@@ -82,7 +82,7 @@ class TcpConnectorTest extends TestCase
         $loop = $this->getMock('React\EventLoop\LoopInterface');
 
         $connector = new TcpConnector($loop);
-        $connector->connect('www.google.com', 80)->then(
+        $connector->connect('www.google.com:80')->then(
             $this->expectCallableNever(),
             $this->expectCallableOnce()
         );
@@ -94,7 +94,7 @@ class TcpConnectorTest extends TestCase
         $loop = $this->getMock('React\EventLoop\LoopInterface');
 
         $connector = new TcpConnector($loop);
-        $connector->connect('255.255.255.255', 12345678)->then(
+        $connector->connect('255.255.255.255:12345678')->then(
             $this->expectCallableNever(),
             $this->expectCallableOnce()
         );
@@ -109,7 +109,7 @@ class TcpConnectorTest extends TestCase
         $server = new Server($loop);
         $server->listen(0);
 
-        $promise = $connector->connect('127.0.0.1', $server->getPort());
+        $promise = $connector->connect('127.0.0.1:' . $server->getPort());
         $promise->cancel();
 
         $this->setExpectedException('RuntimeException', 'Cancelled');

--- a/tests/TcpConnectorTest.php
+++ b/tests/TcpConnectorTest.php
@@ -17,7 +17,7 @@ class TcpConnectorTest extends TestCase
         $loop = new StreamSelectLoop();
 
         $connector = new TcpConnector($loop);
-        $connector->create('127.0.0.1', 9999)
+        $connector->connect('127.0.0.1', 9999)
                 ->then($this->expectCallableNever(), $this->expectCallableOnce());
 
         $loop->run();
@@ -37,7 +37,7 @@ class TcpConnectorTest extends TestCase
 
         $connector = new TcpConnector($loop);
 
-        $stream = Block\await($connector->create('127.0.0.1', 9999), $loop, self::TIMEOUT);
+        $stream = Block\await($connector->connect('127.0.0.1', 9999), $loop, self::TIMEOUT);
 
         $this->assertInstanceOf('React\Stream\Stream', $stream);
 
@@ -51,7 +51,7 @@ class TcpConnectorTest extends TestCase
 
         $connector = new TcpConnector($loop);
         $connector
-            ->create('::1', 9999)
+            ->connect('::1', 9999)
             ->then($this->expectCallableNever(), $this->expectCallableOnce());
 
         $loop->run();
@@ -69,7 +69,7 @@ class TcpConnectorTest extends TestCase
 
         $connector = new TcpConnector($loop);
 
-        $stream = Block\await($connector->create('::1', 9999), $loop, self::TIMEOUT);
+        $stream = Block\await($connector->connect('::1', 9999), $loop, self::TIMEOUT);
 
         $this->assertInstanceOf('React\Stream\Stream', $stream);
 
@@ -82,7 +82,7 @@ class TcpConnectorTest extends TestCase
         $loop = $this->getMock('React\EventLoop\LoopInterface');
 
         $connector = new TcpConnector($loop);
-        $connector->create('www.google.com', 80)->then(
+        $connector->connect('www.google.com', 80)->then(
             $this->expectCallableNever(),
             $this->expectCallableOnce()
         );
@@ -94,7 +94,7 @@ class TcpConnectorTest extends TestCase
         $loop = $this->getMock('React\EventLoop\LoopInterface');
 
         $connector = new TcpConnector($loop);
-        $connector->create('255.255.255.255', 12345678)->then(
+        $connector->connect('255.255.255.255', 12345678)->then(
             $this->expectCallableNever(),
             $this->expectCallableOnce()
         );
@@ -109,7 +109,7 @@ class TcpConnectorTest extends TestCase
         $server = new Server($loop);
         $server->listen(0);
 
-        $promise = $connector->create('127.0.0.1', $server->getPort());
+        $promise = $connector->connect('127.0.0.1', $server->getPort());
         $promise->cancel();
 
         $this->setExpectedException('RuntimeException', 'Cancelled');

--- a/tests/TcpConnectorTest.php
+++ b/tests/TcpConnectorTest.php
@@ -89,12 +89,38 @@ class TcpConnectorTest extends TestCase
     }
 
     /** @test */
-    public function connectionToInvalidAddressShouldFailImmediately()
+    public function connectionToInvalidPortShouldFailImmediately()
     {
         $loop = $this->getMock('React\EventLoop\LoopInterface');
 
         $connector = new TcpConnector($loop);
         $connector->connect('255.255.255.255:12345678')->then(
+            $this->expectCallableNever(),
+            $this->expectCallableOnce()
+        );
+    }
+
+    /** @test */
+    public function connectionToInvalidSchemeShouldFailImmediately()
+    {
+        $loop = $this->getMock('React\EventLoop\LoopInterface');
+
+        $connector = new TcpConnector($loop);
+        $connector->connect('tls://google.com:443')->then(
+            $this->expectCallableNever(),
+            $this->expectCallableOnce()
+        );
+    }
+
+    /** @test */
+    public function connectionWithInvalidContextShouldFailImmediately()
+    {
+        $this->markTestIncomplete();
+
+        $loop = $this->getMock('React\EventLoop\LoopInterface');
+
+        $connector = new TcpConnector($loop, array('bindto' => 'invalid.invalid:123456'));
+        $connector->connect('127.0.0.1:80')->then(
             $this->expectCallableNever(),
             $this->expectCallableOnce()
         );

--- a/tests/TimeoutConnectorTest.php
+++ b/tests/TimeoutConnectorTest.php
@@ -13,13 +13,13 @@ class TimeoutConnectorTest extends TestCase
         $promise = new Promise\Promise(function () { });
 
         $connector = $this->getMock('React\SocketClient\ConnectorInterface');
-        $connector->expects($this->once())->method('connect')->with('google.com', 80)->will($this->returnValue($promise));
+        $connector->expects($this->once())->method('connect')->with('google.com:80')->will($this->returnValue($promise));
 
         $loop = Factory::create();
 
         $timeout = new TimeoutConnector($connector, 0.01, $loop);
 
-        $timeout->connect('google.com', 80)->then(
+        $timeout->connect('google.com:80')->then(
             $this->expectCallableNever(),
             $this->expectCallableOnce()
         );
@@ -32,13 +32,13 @@ class TimeoutConnectorTest extends TestCase
         $promise = Promise\reject(new \RuntimeException());
 
         $connector = $this->getMock('React\SocketClient\ConnectorInterface');
-        $connector->expects($this->once())->method('connect')->with('google.com', 80)->will($this->returnValue($promise));
+        $connector->expects($this->once())->method('connect')->with('google.com:80')->will($this->returnValue($promise));
 
         $loop = Factory::create();
 
         $timeout = new TimeoutConnector($connector, 5.0, $loop);
 
-        $timeout->connect('google.com', 80)->then(
+        $timeout->connect('google.com:80')->then(
             $this->expectCallableNever(),
             $this->expectCallableOnce()
         );
@@ -51,13 +51,13 @@ class TimeoutConnectorTest extends TestCase
         $promise = Promise\resolve();
 
         $connector = $this->getMock('React\SocketClient\ConnectorInterface');
-        $connector->expects($this->once())->method('connect')->with('google.com', 80)->will($this->returnValue($promise));
+        $connector->expects($this->once())->method('connect')->with('google.com:80')->will($this->returnValue($promise));
 
         $loop = Factory::create();
 
         $timeout = new TimeoutConnector($connector, 5.0, $loop);
 
-        $timeout->connect('google.com', 80)->then(
+        $timeout->connect('google.com:80')->then(
             $this->expectCallableOnce(),
             $this->expectCallableNever()
         );
@@ -70,13 +70,13 @@ class TimeoutConnectorTest extends TestCase
         $promise = new Promise\Promise(function () { }, $this->expectCallableOnce());
 
         $connector = $this->getMock('React\SocketClient\ConnectorInterface');
-        $connector->expects($this->once())->method('connect')->with('google.com', 80)->will($this->returnValue($promise));
+        $connector->expects($this->once())->method('connect')->with('google.com:80')->will($this->returnValue($promise));
 
         $loop = Factory::create();
 
         $timeout = new TimeoutConnector($connector, 0.01, $loop);
 
-        $timeout->connect('google.com', 80)->then(
+        $timeout->connect('google.com:80')->then(
             $this->expectCallableNever(),
             $this->expectCallableOnce()
         );
@@ -89,13 +89,13 @@ class TimeoutConnectorTest extends TestCase
         $promise = new Promise\Promise(function () { }, $this->expectCallableOnce());
 
         $connector = $this->getMock('React\SocketClient\ConnectorInterface');
-        $connector->expects($this->once())->method('connect')->with('google.com', 80)->will($this->returnValue($promise));
+        $connector->expects($this->once())->method('connect')->with('google.com:80')->will($this->returnValue($promise));
 
         $loop = Factory::create();
 
         $timeout = new TimeoutConnector($connector, 0.01, $loop);
 
-        $out = $timeout->connect('google.com', 80);
+        $out = $timeout->connect('google.com:80');
         $out->cancel();
 
         $out->then($this->expectCallableNever(), $this->expectCallableOnce());
@@ -111,13 +111,13 @@ class TimeoutConnectorTest extends TestCase
         });
 
         $connector = $this->getMock('React\SocketClient\ConnectorInterface');
-        $connector->expects($this->once())->method('connect')->with('google.com', 80)->will($this->returnValue($promise));
+        $connector->expects($this->once())->method('connect')->with('google.com:80')->will($this->returnValue($promise));
 
         $loop = Factory::create();
 
         $timeout = new TimeoutConnector($connector, 0.01, $loop);
 
-        $out = $timeout->connect('google.com', 80);
+        $out = $timeout->connect('google.com:80');
         $out->cancel();
 
         $out->then($this->expectCallableNever(), $this->expectCallableOnce());

--- a/tests/TimeoutConnectorTest.php
+++ b/tests/TimeoutConnectorTest.php
@@ -13,13 +13,13 @@ class TimeoutConnectorTest extends TestCase
         $promise = new Promise\Promise(function () { });
 
         $connector = $this->getMock('React\SocketClient\ConnectorInterface');
-        $connector->expects($this->once())->method('create')->with('google.com', 80)->will($this->returnValue($promise));
+        $connector->expects($this->once())->method('connect')->with('google.com', 80)->will($this->returnValue($promise));
 
         $loop = Factory::create();
 
         $timeout = new TimeoutConnector($connector, 0.01, $loop);
 
-        $timeout->create('google.com', 80)->then(
+        $timeout->connect('google.com', 80)->then(
             $this->expectCallableNever(),
             $this->expectCallableOnce()
         );
@@ -32,13 +32,13 @@ class TimeoutConnectorTest extends TestCase
         $promise = Promise\reject(new \RuntimeException());
 
         $connector = $this->getMock('React\SocketClient\ConnectorInterface');
-        $connector->expects($this->once())->method('create')->with('google.com', 80)->will($this->returnValue($promise));
+        $connector->expects($this->once())->method('connect')->with('google.com', 80)->will($this->returnValue($promise));
 
         $loop = Factory::create();
 
         $timeout = new TimeoutConnector($connector, 5.0, $loop);
 
-        $timeout->create('google.com', 80)->then(
+        $timeout->connect('google.com', 80)->then(
             $this->expectCallableNever(),
             $this->expectCallableOnce()
         );
@@ -51,13 +51,13 @@ class TimeoutConnectorTest extends TestCase
         $promise = Promise\resolve();
 
         $connector = $this->getMock('React\SocketClient\ConnectorInterface');
-        $connector->expects($this->once())->method('create')->with('google.com', 80)->will($this->returnValue($promise));
+        $connector->expects($this->once())->method('connect')->with('google.com', 80)->will($this->returnValue($promise));
 
         $loop = Factory::create();
 
         $timeout = new TimeoutConnector($connector, 5.0, $loop);
 
-        $timeout->create('google.com', 80)->then(
+        $timeout->connect('google.com', 80)->then(
             $this->expectCallableOnce(),
             $this->expectCallableNever()
         );
@@ -70,13 +70,13 @@ class TimeoutConnectorTest extends TestCase
         $promise = new Promise\Promise(function () { }, $this->expectCallableOnce());
 
         $connector = $this->getMock('React\SocketClient\ConnectorInterface');
-        $connector->expects($this->once())->method('create')->with('google.com', 80)->will($this->returnValue($promise));
+        $connector->expects($this->once())->method('connect')->with('google.com', 80)->will($this->returnValue($promise));
 
         $loop = Factory::create();
 
         $timeout = new TimeoutConnector($connector, 0.01, $loop);
 
-        $timeout->create('google.com', 80)->then(
+        $timeout->connect('google.com', 80)->then(
             $this->expectCallableNever(),
             $this->expectCallableOnce()
         );
@@ -89,13 +89,13 @@ class TimeoutConnectorTest extends TestCase
         $promise = new Promise\Promise(function () { }, $this->expectCallableOnce());
 
         $connector = $this->getMock('React\SocketClient\ConnectorInterface');
-        $connector->expects($this->once())->method('create')->with('google.com', 80)->will($this->returnValue($promise));
+        $connector->expects($this->once())->method('connect')->with('google.com', 80)->will($this->returnValue($promise));
 
         $loop = Factory::create();
 
         $timeout = new TimeoutConnector($connector, 0.01, $loop);
 
-        $out = $timeout->create('google.com', 80);
+        $out = $timeout->connect('google.com', 80);
         $out->cancel();
 
         $out->then($this->expectCallableNever(), $this->expectCallableOnce());
@@ -111,13 +111,13 @@ class TimeoutConnectorTest extends TestCase
         });
 
         $connector = $this->getMock('React\SocketClient\ConnectorInterface');
-        $connector->expects($this->once())->method('create')->with('google.com', 80)->will($this->returnValue($promise));
+        $connector->expects($this->once())->method('connect')->with('google.com', 80)->will($this->returnValue($promise));
 
         $loop = Factory::create();
 
         $timeout = new TimeoutConnector($connector, 0.01, $loop);
 
-        $out = $timeout->create('google.com', 80);
+        $out = $timeout->connect('google.com', 80);
         $out->cancel();
 
         $out->then($this->expectCallableNever(), $this->expectCallableOnce());

--- a/tests/UnixConnectorTest.php
+++ b/tests/UnixConnectorTest.php
@@ -17,7 +17,7 @@ class UnixConnectorTest extends TestCase
 
     public function testInvalid()
     {
-        $promise = $this->connector->create('google.com', 80);
+        $promise = $this->connector->connect('google.com', 80);
         $promise->then(null, $this->expectCallableOnce());
     }
 
@@ -36,7 +36,7 @@ class UnixConnectorTest extends TestCase
         }
 
         // tests succeeds if we get notified of successful connection
-        $promise = $this->connector->create($path, 0);
+        $promise = $this->connector->connect($path, 0);
         $promise->then($this->expectCallableOnce());
 
         // clean up server

--- a/tests/UnixConnectorTest.php
+++ b/tests/UnixConnectorTest.php
@@ -17,7 +17,7 @@ class UnixConnectorTest extends TestCase
 
     public function testInvalid()
     {
-        $promise = $this->connector->connect('google.com', 80);
+        $promise = $this->connector->connect('google.com:80');
         $promise->then(null, $this->expectCallableOnce());
     }
 
@@ -36,7 +36,7 @@ class UnixConnectorTest extends TestCase
         }
 
         // tests succeeds if we get notified of successful connection
-        $promise = $this->connector->connect($path, 0);
+        $promise = $this->connector->connect($path);
         $promise->then($this->expectCallableOnce());
 
         // clean up server

--- a/tests/UnixConnectorTest.php
+++ b/tests/UnixConnectorTest.php
@@ -21,6 +21,12 @@ class UnixConnectorTest extends TestCase
         $promise->then(null, $this->expectCallableOnce());
     }
 
+    public function testInvalidScheme()
+    {
+        $promise = $this->connector->connect('tcp://google.com:80');
+        $promise->then(null, $this->expectCallableOnce());
+    }
+
     public function testValid()
     {
         // random unix domain socket path


### PR DESCRIPTION
This PR combines dedicated `$host` and `$uri` parameters into a single `$uri`. This is obviously a BC break, so let's rename the method to a more meaningful name while we're at it.

There are plenty of reasons, let me try to list a few here:

* URIs are literally the only way to provide a consistent addressing scheme throughout React's components, see https://github.com/reactphp/react/issues/199
* Not all protocols know the concept of a "port", for example our `UnixConnector` currently has an unused `$port` parameter
* URIs are a prerequisite for adding a simpler facade API (#38) that can automatically pick the *right* underlying connector based on the URI scheme
* Prerequisite for passing the original hostname as a parameter to the underlying resource creation for SNI support for legacy PHP versions (#66)
* Potential to add custom schemes and default ports for certain protocols
* Supersedes / closes #9

See also the individual commits if you want to review the changes.