### PR TITLE
Skip IPv6 tests if not supported by the system

### DIFF
--- a/tests/TcpConnectorTest.php
+++ b/tests/TcpConnectorTest.php
@@ -65,7 +65,12 @@ class TcpConnectorTest extends TestCase
         $server = new Server($loop);
         $server->on('connection', $this->expectCallableOnce());
         $server->on('connection', array($server, 'shutdown'));
-        $server->listen(9999, '::1');
+
+        try {
+            $server->listen(9999, '::1');
+        } catch (\Exception $e) {
+            $this->markTestSkipped('Unable to start IPv6 server socket (IPv6 not supported on this system?)');
+        }
 
         $connector = new TcpConnector($loop);
 


### PR DESCRIPTION
In particular, Travis' legacy infrastructure does not provide IPv6 support which currently causes the tests in reactphp/react to fail.