### PR TITLE
Require cancellation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ $connector->connect('google.com:443')->then(
 );
 ```
 
-The returned Promise SHOULD be implemented in such a way that it can be
-cancelled when it is still pending. Cancelling a pending promise SHOULD
+The returned Promise MUST be implemented in such a way that it can be
+cancelled when it is still pending. Cancelling a pending promise MUST
 reject its value with an `Exception`. It SHOULD clean up any underlying
 resources and references as applicable:
 

--- a/src/ConnectorInterface.php
+++ b/src/ConnectorInterface.php
@@ -25,8 +25,8 @@ interface ConnectorInterface
      * The Promise resolves with a `React\Stream\Stream` instance on success or
      * rejects with an `Exception` if the connection is not successful.
      *
-     * The returned Promise SHOULD be implemented in such a way that it can be
-     * cancelled when it is still pending. Cancelling a pending promise SHOULD
+     * The returned Promise MUST be implemented in such a way that it can be
+     * cancelled when it is still pending. Cancelling a pending promise MUST
      * reject its value with an Exception. It SHOULD clean up any underlying
      * resources and references as applicable.
      *

--- a/src/TimeoutConnector.php
+++ b/src/TimeoutConnector.php
@@ -24,27 +24,6 @@ class TimeoutConnector implements ConnectorInterface
 
     public function connect($uri)
     {
-        $promise = $this->connector->connect($uri);
-
-        return Timer\timeout(new Promise(
-            function ($resolve, $reject) use ($promise) {
-                // resolve/reject with result of TCP/IP connection
-                $promise->then($resolve, $reject);
-            },
-            function ($_, $reject) use ($promise) {
-                // cancellation should reject connection attempt
-                $reject(new \RuntimeException('Connection attempt cancelled during connection'));
-
-                // forefully close TCP/IP connection if it completes despite cancellation
-                $promise->then(function (Stream $stream) {
-                    $stream->close();
-                });
-
-                // (try to) cancel pending TCP/IP connection
-                if ($promise instanceof CancellablePromiseInterface) {
-                    $promise->cancel();
-                }
-            }
-        ), $this->timeout, $this->loop);
+        return Timer\timeout($this->connector->connect($uri), $this->timeout, $this->loop);
     }
 }

--- a/tests/DnsConnectorTest.php
+++ b/tests/DnsConnectorTest.php
@@ -73,7 +73,7 @@ class DnsConnectorTest extends TestCase
     {
         $pending = new Promise\Promise(function () { }, $this->expectCallableOnce());
         $this->resolver->expects($this->once())->method('resolve')->with($this->equalTo('example.com'))->will($this->returnValue($pending));
-        $this->tcp->expects($this->never())->method('resolve');
+        $this->tcp->expects($this->never())->method('connect');
 
         $promise = $this->connector->connect('example.com:80');
         $promise->cancel();
@@ -83,25 +83,7 @@ class DnsConnectorTest extends TestCase
 
     public function testCancelDuringTcpConnectionCancelsTcpConnection()
     {
-        $pending = new Promise\Promise(function () { }, $this->expectCallableOnce());
-        $this->resolver->expects($this->once())->method('resolve')->with($this->equalTo('example.com'))->will($this->returnValue(Promise\resolve('1.2.3.4')));
-        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('1.2.3.4:80'))->will($this->returnValue($pending));
-
-        $promise = $this->connector->connect('example.com:80');
-        $promise->cancel();
-
-        $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
-    }
-
-    public function testCancelClosesStreamIfTcpResolvesDespiteCancellation()
-    {
-        $stream = $this->getMockBuilder('React\Stream\Stream')->disableOriginalConstructor()->setMethods(array('close'))->getMock();
-        $stream->expects($this->once())->method('close');
-
-        $pending = new Promise\Promise(function () { }, function ($resolve) use ($stream) {
-            $resolve($stream);
-        });
-
+        $pending = new Promise\Promise(function () { }, function () { throw new \Exception(); });
         $this->resolver->expects($this->once())->method('resolve')->with($this->equalTo('example.com'))->will($this->returnValue(Promise\resolve('1.2.3.4')));
         $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('1.2.3.4:80'))->will($this->returnValue($pending));
 

--- a/tests/SecureConnectorTest.php
+++ b/tests/SecureConnectorTest.php
@@ -51,24 +51,7 @@ class SecureConnectorTest extends TestCase
 
     public function testCancelDuringTcpConnectionCancelsTcpConnection()
     {
-        $pending = new Promise\Promise(function () { }, $this->expectCallableOnce());
-        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('example.com:80'))->will($this->returnValue($pending));
-
-        $promise = $this->connector->connect('example.com:80');
-        $promise->cancel();
-
-        $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
-    }
-
-    public function testCancelClosesStreamIfTcpResolvesDespiteCancellation()
-    {
-        $stream = $this->getMockBuilder('React\Stream\Stream')->disableOriginalConstructor()->setMethods(array('close'))->getMock();
-        $stream->expects($this->once())->method('close');
-
-        $pending = new Promise\Promise(function () { }, function ($resolve) use ($stream) {
-            $resolve($stream);
-        });
-
+        $pending = new Promise\Promise(function () { }, function () { throw new \Exception(); });
         $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('example.com:80'))->will($this->returnValue($pending));
 
         $promise = $this->connector->connect('example.com:80');

--- a/tests/TimeoutConnectorTest.php
+++ b/tests/TimeoutConnectorTest.php
@@ -86,29 +86,7 @@ class TimeoutConnectorTest extends TestCase
 
     public function testCancelsPendingPromiseOnCancel()
     {
-        $promise = new Promise\Promise(function () { }, $this->expectCallableOnce());
-
-        $connector = $this->getMock('React\SocketClient\ConnectorInterface');
-        $connector->expects($this->once())->method('connect')->with('google.com:80')->will($this->returnValue($promise));
-
-        $loop = Factory::create();
-
-        $timeout = new TimeoutConnector($connector, 0.01, $loop);
-
-        $out = $timeout->connect('google.com:80');
-        $out->cancel();
-
-        $out->then($this->expectCallableNever(), $this->expectCallableOnce());
-    }
-
-    public function testCancelClosesStreamIfTcpResolvesDespiteCancellation()
-    {
-        $stream = $this->getMockBuilder('React\Stream\Stream')->disableOriginalConstructor()->setMethods(array('close'))->getMock();
-        $stream->expects($this->once())->method('close');
-
-        $promise = new Promise\Promise(function () { }, function ($resolve) use ($stream) {
-            $resolve($stream);
-        });
+        $promise = new Promise\Promise(function () { }, function () { throw new \Exception(); });
 
         $connector = $this->getMock('React\SocketClient\ConnectorInterface');
         $connector->expects($this->once())->method('connect')->with('google.com:80')->will($this->returnValue($promise));


### PR DESCRIPTION
Builds on top of cancellation support introduced via #71 in v0.5.1.

This is a feature from the consumer perspective and a BC break only for implementors of this interface.