### PR TITLE
Connections now resolve with a ConnectionInterface

### DIFF
--- a/examples/01-http.php
+++ b/examples/01-http.php
@@ -3,8 +3,8 @@
 use React\EventLoop\Factory;
 use React\SocketClient\TcpConnector;
 use React\SocketClient\DnsConnector;
-use React\Stream\Stream;
 use React\SocketClient\TimeoutConnector;
+use React\SocketClient\ConnectionInterface;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -19,15 +19,15 @@ $dns = new DnsConnector($tcp, $resolver);
 // time out connection attempt in 3.0s
 $dns = new TimeoutConnector($dns, 3.0, $loop);
 
-$dns->create('www.google.com', 80)->then(function (Stream $stream) {
-    $stream->on('data', function ($data) {
+$dns->create('www.google.com', 80)->then(function (ConnectionInterface $connection) {
+    $connection->on('data', function ($data) {
         echo $data;
     });
-    $stream->on('close', function () {
+    $connection->on('close', function () {
         echo '[CLOSED]' . PHP_EOL;
     });
 
-    $stream->write("GET / HTTP/1.0\r\nHost: www.google.com\r\n\r\n");
+    $connection->write("GET / HTTP/1.0\r\nHost: www.google.com\r\n\r\n");
 }, 'printf');
 
 $loop->run();

--- a/examples/02-https.php
+++ b/examples/02-https.php
@@ -4,8 +4,8 @@ use React\EventLoop\Factory;
 use React\SocketClient\TcpConnector;
 use React\SocketClient\DnsConnector;
 use React\SocketClient\SecureConnector;
-use React\Stream\Stream;
 use React\SocketClient\TimeoutConnector;
+use React\SocketClient\ConnectionInterface;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -21,15 +21,15 @@ $tls = new SecureConnector($dns, $loop);
 // time out connection attempt in 3.0s
 $tls = new TimeoutConnector($tls, 3.0, $loop);
 
-$tls->create('www.google.com', 443)->then(function (Stream $stream) {
-    $stream->on('data', function ($data) {
+$tls->create('www.google.com', 443)->then(function (ConnectionInterface $connection) {
+    $connection->on('data', function ($data) {
         echo $data;
     });
-    $stream->on('close', function () {
+    $connection->on('close', function () {
         echo '[CLOSED]' . PHP_EOL;
     });
 
-    $stream->write("GET / HTTP/1.0\r\nHost: www.google.com\r\n\r\n");
+    $connection->write("GET / HTTP/1.0\r\nHost: www.google.com\r\n\r\n");
 }, 'printf');
 
 $loop->run();

--- a/examples/03-netcat.php
+++ b/examples/03-netcat.php
@@ -3,8 +3,8 @@
 use React\EventLoop\Factory;
 use React\SocketClient\TcpConnector;
 use React\SocketClient\DnsConnector;
-use React\Stream\Stream;
 use React\SocketClient\TimeoutConnector;
+use React\SocketClient\ConnectionInterface;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -33,21 +33,21 @@ $stderr->pause();
 
 $stderr->write('Connecting' . PHP_EOL);
 
-$dns->create($argv[1], $argv[2])->then(function (Stream $stream) use ($stdin, $stdout, $stderr) {
+$dns->create($argv[1], $argv[2])->then(function (ConnectionInterface $connection) use ($stdin, $stdout, $stderr) {
     // pipe everything from STDIN into connection
     $stdin->resume();
-    $stdin->pipe($stream);
+    $stdin->pipe($connection);
 
     // pipe everything from connection to STDOUT
-    $stream->pipe($stdout);
+    $connection->pipe($stdout);
 
     // report errors to STDERR
-    $stream->on('error', function ($error) use ($stderr) {
+    $connection->on('error', function ($error) use ($stderr) {
         $stderr->write('Stream ERROR: ' . $error . PHP_EOL);
     });
 
     // report closing and stop reading from input
-    $stream->on('close', function () use ($stderr, $stdin) {
+    $connection->on('close', function () use ($stderr, $stdin) {
         $stderr->write('[CLOSED]' . PHP_EOL);
         $stdin->close();
     });

--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace React\SocketClient;
+
+use React\Stream\DuplexStreamInterface;
+
+/**
+ * Any outgoing connection is represented by this interface,
+ * such as a normal TCP/IP connection.
+ *
+ * An outgoing connection is a duplex stream (both readable and writable) that
+ * implements React's
+ * [`DuplexStreamInterface`](https://github.com/reactphp/stream#duplexstreaminterface).
+ * It contains additional properties for the local and remote address
+ * where this connection has been established to.
+ *
+ * Most commonly, instances implementing this `ConnectionInterface` are returned
+ * by all classes implementing the [`ConnectorInterface`](#connectorinterface).
+ *
+ * > Note that this interface is only to be used to represent the client-side end
+ * of an outgoing connection.
+ * It MUST NOT be used to represent an incoming connection in a server-side context.
+ * If you want to accept incoming connections,
+ * use the [`Socket`](https://github.com/reactphp/socket) component instead.
+ *
+ * Because the `ConnectionInterface` implements the underlying
+ * [`DuplexStreamInterface`](https://github.com/reactphp/stream#duplexstreaminterface)
+ * you can use any of its events and methods as usual:
+ *
+ * ```php
+ * $connection->on('data', function ($chunk) {
+ *     echo $data;
+ * });
+ *
+ * $conenction->on('close', function () {
+ *     echo 'closed';
+ * });
+ *
+ * $connection->write($data);
+ * $connection->end($data = null);
+ * $connection->close();
+ * // …
+ * ```
+ *
+ * For more details, see the
+ * [`DuplexStreamInterface`](https://github.com/reactphp/stream#duplexstreaminterface).
+ *
+ * @see DuplexStreamInterface
+ * @see ConnectorInterface
+ */
+interface ConnectionInterface extends DuplexStreamInterface
+{
+    /**
+     * Returns the remote address (IP and port) where this connection has been established to
+     *
+     * ```php
+     * $address = $connection->getRemoteAddress();
+     * echo 'Connected to ' . $address . PHP_EOL;
+     * ```
+     *
+     * If the remote address can not be determined or is unknown at this time (such as
+     * after the connection has been closed), it MAY return a `NULL` value instead.
+     *
+     * Otherwise, it will return the full remote address as a string value.
+     * If this is a TCP/IP based connection and you only want the remote IP, you may
+     * use something like this:
+     *
+     * ```php
+     * $address = $connection->getRemoteAddress();
+     * $ip = trim(parse_url('tcp://' . $address, PHP_URL_HOST), '[]');
+     * echo 'Connected to ' . $ip . PHP_EOL;
+     * ```
+     *
+     * @return ?string remote address (IP and port) or null if unknown
+     */
+    public function getRemoteAddress();
+
+    /**
+     * Returns the full local address (IP and port) where this connection has been established from
+     *
+     * ```php
+     * $address = $connection->getLocalAddress();
+     * echo 'Connected via ' . $address . PHP_EOL;
+     * ```
+     *
+     * If the local address can not be determined or is unknown at this time (such as
+     * after the connection has been closed), it MAY return a `NULL` value instead.
+     *
+     * Otherwise, it will return the full local address as a string value.
+     *
+     * This method complements the [`getRemoteAddress()`](#getremoteaddress) method,
+     * so they should not be confused.
+     *
+     * If your system has multiple interfaces (e.g. a WAN and a LAN interface),
+     * you can use this method to find out which interface was actually
+     * used for this connection.
+     *
+     * @return ?string local address (IP and port) or null if unknown
+     * @see self::getRemoteAddress()
+     */
+    public function getLocalAddress();
+}

--- a/src/ConnectorInterface.php
+++ b/src/ConnectorInterface.php
@@ -16,22 +16,43 @@ namespace React\SocketClient;
  * swap this implementation against any other implementation of this interface.
  *
  * The interface only offers a single `connect()` method.
+ *
+ * @see ConnectionInterface
  */
 interface ConnectorInterface
 {
     /**
-     * Creates a Promise which resolves with a stream once the connection to the given remote address succeeds
+     * Creates a streaming connection to the given remote address
      *
-     * The Promise resolves with a `React\Stream\Stream` instance on success or
-     * rejects with an `Exception` if the connection is not successful.
+     * If returns a Promise which either fulfills with a stream implementing
+     * `ConnectionInterface` on success or rejects with an `Exception` if the
+     * connection is not successful.
+     *
+     * ```php
+     * $connector->connect('google.com:443')->then(
+     *     function (ConnectionInterface $connection) {
+     *         // connection successfully established
+     *     },
+     *     function (Exception $error) {
+     *         // failed to connect due to $error
+     *     }
+     * );
+     * ```
      *
      * The returned Promise MUST be implemented in such a way that it can be
      * cancelled when it is still pending. Cancelling a pending promise MUST
      * reject its value with an Exception. It SHOULD clean up any underlying
      * resources and references as applicable.
      *
+     * ```php
+     * $promise = $connector->connect($uri);
+     *
+     * $promise->cancel();
+     * ```
+     *
      * @param string $uri
-     * @return React\Promise\PromiseInterface resolves with a Stream on success or rejects with an Exception on error
+     * @return React\Promise\PromiseInterface resolves with a stream implementing ConnectionInterface on success or rejects with an Exception on error
+     * @see ConnectionInterface
      */
     public function connect($uri);
 }

--- a/src/StreamConnection.php
+++ b/src/StreamConnection.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace React\SocketClient;
+
+use React\Stream\Stream;
+use React\SocketClient\ConnectionInterface;
+
+/**
+ * @internal should not be relied upon, see ConnectionInterface instead
+ * @see ConnectionInterface
+ */
+class StreamConnection extends Stream implements ConnectionInterface
+{
+    public function getRemoteAddress()
+    {
+        return $this->sanitizeAddress(@stream_socket_get_name($this->stream, true));
+    }
+
+    public function getLocalAddress()
+    {
+        return $this->sanitizeAddress(@stream_socket_get_name($this->stream, false));
+    }
+
+    private function sanitizeAddress($address)
+    {
+        if ($address === false) {
+            return null;
+        }
+
+        // check if this is an IPv6 address which includes multiple colons but no square brackets
+        $pos = strrpos($address, ':');
+        if ($pos !== false && strpos($address, ':') < $pos && substr($address, 0, 1) !== '[') {
+            $port = substr($address, $pos + 1);
+            $address = '[' . substr($address, 0, $pos) . ']:' . $port;
+        }
+
+        return $address;
+    }
+}

--- a/src/TcpConnector.php
+++ b/src/TcpConnector.php
@@ -96,6 +96,6 @@ class TcpConnector implements ConnectorInterface
     /** @internal */
     public function handleConnectedSocket($socket)
     {
-        return new Stream($socket, $this->loop);
+        return new StreamConnection($socket, $this->loop);
     }
 }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -26,6 +26,9 @@ class IntegrationTest extends TestCase
 
         $conn = Block\await($connector->connect('google.com:80'), $loop);
 
+        $this->assertContains(':80', $conn->getRemoteAddress());
+        $this->assertNotEquals('google.com:80', $conn->getRemoteAddress());
+
         $conn->write("GET / HTTP/1.0\r\n\r\n");
 
         $response = Block\await(BufferedSink::createPromise($conn), $loop, self::TIMEOUT);

--- a/tests/SecureConnectorTest.php
+++ b/tests/SecureConnectorTest.php
@@ -59,4 +59,16 @@ class SecureConnectorTest extends TestCase
 
         $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
     }
+
+    public function testConnectionWillBeClosedAndRejectedIfConnectioIsNoStream()
+    {
+        $connection = $this->getMockBuilder('React\SocketClient\ConnectionInterface')->getMock();
+        $connection->expects($this->once())->method('close');
+
+        $this->tcp->expects($this->once())->method('connect')->with($this->equalTo('example.com:80'))->willReturn(Promise\resolve($connection));
+
+        $promise = $this->connector->connect('example.com:80');
+
+        $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
+    }
 }


### PR DESCRIPTION
This PR changes the resolution value from `Stream` (which implements the `DuplexStreamInterface`) to an instance implementing the new `ConnectionInterface`, which in turn implements the `DuplexStreamInterface`.

In other words: Each `ConnectorInterface` now has a `connect()` method that resolves to a `ConnectionInterface`.

Because the `ConnectionInterface` implements the same base interface `DuplexStreamInterface`, it behaves just like a normal stream resource, so consumer code can simply use the new typehint and continue to work unchanged.

The `ConnectionInterface` also implements two new methods which are not available for the underlying stream:
* `getRemoteAddress(): ?string`
* `getLocalAddress(): ?string`

Resolves / closes #44
Refs https://github.com/reactphp/react/issues/199
Refs https://github.com/reactphp/socket/pull/65
Refs https://github.com/reactphp/socket/pull/68