### PR TITLE
Mark all connector classes as final

### DIFF
--- a/src/Connector.php
+++ b/src/Connector.php
@@ -15,7 +15,7 @@ use React\Dns\Resolver\Resolver;
  * @see DnsConnector for the newer replacement
  * @see ConnectorInterface for the base interface
  */
-class Connector implements ConnectorInterface
+final class Connector implements ConnectorInterface
 {
     private $connector;
 

--- a/src/DnsConnector.php
+++ b/src/DnsConnector.php
@@ -3,11 +3,10 @@
 namespace React\SocketClient;
 
 use React\Dns\Resolver\Resolver;
-use React\Stream\Stream;
 use React\Promise;
 use React\Promise\CancellablePromiseInterface;
 
-class DnsConnector implements ConnectorInterface
+final class DnsConnector implements ConnectorInterface
 {
     private $connector;
     private $resolver;

--- a/src/SecureConnector.php
+++ b/src/SecureConnector.php
@@ -5,9 +5,8 @@ namespace React\SocketClient;
 use React\EventLoop\LoopInterface;
 use React\Stream\Stream;
 use React\Promise;
-use React\Promise\CancellablePromiseInterface;
 
-class SecureConnector implements ConnectorInterface
+final class SecureConnector implements ConnectorInterface
 {
     private $connector;
     private $streamEncryption;

--- a/src/TcpConnector.php
+++ b/src/TcpConnector.php
@@ -3,12 +3,10 @@
 namespace React\SocketClient;
 
 use React\EventLoop\LoopInterface;
-use React\Dns\Resolver\Resolver;
 use React\Stream\Stream;
 use React\Promise;
-use React\Promise\Deferred;
 
-class TcpConnector implements ConnectorInterface
+final class TcpConnector implements ConnectorInterface
 {
     private $loop;
     private $context;

--- a/src/TimeoutConnector.php
+++ b/src/TimeoutConnector.php
@@ -5,11 +5,8 @@ namespace React\SocketClient;
 use React\SocketClient\ConnectorInterface;
 use React\EventLoop\LoopInterface;
 use React\Promise\Timer;
-use React\Stream\Stream;
-use React\Promise\Promise;
-use React\Promise\CancellablePromiseInterface;
 
-class TimeoutConnector implements ConnectorInterface
+final class TimeoutConnector implements ConnectorInterface
 {
     private $connector;
     private $timeout;

--- a/src/UnixConnector.php
+++ b/src/UnixConnector.php
@@ -14,7 +14,7 @@ use RuntimeException;
  * Unix domain sockets use atomic operations, so we can as well emulate
  * async behavior.
  */
-class UnixConnector implements ConnectorInterface
+final class UnixConnector implements ConnectorInterface
 {
     private $loop;
 


### PR DESCRIPTION
Classes should be used via composition rather than extension.
This reduces our API footprint and avoids future BC breaks by avoiding
exposing its internal assumptions.

Refs https://github.com/reactphp/socket/pull/71