### PR TITLE
Pass through original host to underlying TcpConnector for TLS setup (fixes SNI on legacy PHP < 5.6)

### DIFF
--- a/examples/01-http.php
+++ b/examples/01-http.php
@@ -19,7 +19,9 @@ $dns = new DnsConnector($tcp, $resolver);
 // time out connection attempt in 3.0s
 $dns = new TimeoutConnector($dns, 3.0, $loop);
 
-$dns->connect('www.google.com:80')->then(function (ConnectionInterface $connection) {
+$target = isset($argv[1]) ? $argv[1] : 'www.google.com:80';
+
+$dns->connect($target)->then(function (ConnectionInterface $connection) use ($target) {
     $connection->on('data', function ($data) {
         echo $data;
     });
@@ -27,7 +29,7 @@ $dns->connect('www.google.com:80')->then(function (ConnectionInterface $connecti
         echo '[CLOSED]' . PHP_EOL;
     });
 
-    $connection->write("GET / HTTP/1.0\r\nHost: www.google.com\r\n\r\n");
+    $connection->write("GET / HTTP/1.0\r\nHost: $target\r\n\r\n");
 }, 'printf');
 
 $loop->run();

--- a/examples/02-https.php
+++ b/examples/02-https.php
@@ -21,7 +21,9 @@ $tls = new SecureConnector($dns, $loop);
 // time out connection attempt in 3.0s
 $tls = new TimeoutConnector($tls, 3.0, $loop);
 
-$tls->connect('www.google.com:443')->then(function (ConnectionInterface $connection) {
+$target = isset($argv[1]) ? $argv[1] : 'www.google.com:443';
+
+$tls->connect($target)->then(function (ConnectionInterface $connection) use ($target) {
     $connection->on('data', function ($data) {
         echo $data;
     });
@@ -29,7 +31,7 @@ $tls->connect('www.google.com:443')->then(function (ConnectionInterface $connect
         echo '[CLOSED]' . PHP_EOL;
     });
 
-    $connection->write("GET / HTTP/1.0\r\nHost: www.google.com\r\n\r\n");
+    $connection->write("GET / HTTP/1.0\r\nHost: $target\r\n\r\n");
 }, 'printf');
 
 $loop->run();

--- a/src/SecureConnector.php
+++ b/src/SecureConnector.php
@@ -30,25 +30,12 @@ final class SecureConnector implements ConnectorInterface
         }
 
         $parts = parse_url($uri);
-        if (!$parts || !isset($parts['host']) || $parts['scheme'] !== 'tls') {
+        if (!$parts || !isset($parts['scheme']) || $parts['scheme'] !== 'tls') {
             return Promise\reject(new \InvalidArgumentException('Given URI "' . $uri . '" is invalid'));
         }
 
         $uri = str_replace('tls://', '', $uri);
-        $host = trim($parts['host'], '[]');
-
-        $context = $this->context + array(
-            'SNI_enabled' => true,
-            'peer_name' => $host
-        );
-
-        // legacy PHP < 5.6 ignores peer_name and requires legacy context options instead
-        if (PHP_VERSION_ID < 50600) {
-            $context += array(
-                'SNI_server_name' => $host,
-                'CN_match' => $host
-            );
-        }
+        $context = $this->context;
 
         $encryption = $this->streamEncryption;
         return $this->connector->connect($uri)->then(function (ConnectionInterface $connection) use ($context, $encryption) {

--- a/src/TcpConnector.php
+++ b/src/TcpConnector.php
@@ -66,6 +66,12 @@ final class TcpConnector implements ConnectorInterface
             }
         }
 
+        // HHVM fails to parse URIs with a query but no path, so let's add a dummy path
+        // See also https://3v4l.org/jEhLF
+        if (defined('HHVM_VERSION') && isset($parts['query']) && !isset($parts['path'])) {
+            $uri = str_replace('?', '/?', $uri);
+        }
+
         $socket = @stream_socket_client(
             $uri,
             $errno,

--- a/src/TcpConnector.php
+++ b/src/TcpConnector.php
@@ -33,13 +33,46 @@ final class TcpConnector implements ConnectorInterface
             return Promise\reject(new \InvalidArgumentException('Given URI "' . $ip . '" does not contain a valid host IP'));
         }
 
+        // use context given in constructor
+        $context = array(
+            'socket' => $this->context
+        );
+
+        // parse arguments from query component of URI
+        $args = array();
+        if (isset($parts['query'])) {
+            parse_str($parts['query'], $args);
+        }
+
+        // If an original hostname has been given, use this for TLS setup.
+        // This can happen due to layers of nested connectors, such as a
+        // DnsConnector reporting its original hostname.
+        // These context options are here in case TLS is enabled later on this stream.
+        // If TLS is not enabled later, this doesn't hurt either.
+        if (isset($args['hostname'])) {
+            $context['ssl'] = array(
+                'SNI_enabled' => true,
+                'peer_name' => $args['hostname']
+            );
+
+            // Legacy PHP < 5.6 ignores peer_name and requires legacy context options instead.
+            // The SNI_server_name context option has to be set here during construction,
+            // as legacy PHP ignores any values set later.
+            if (PHP_VERSION_ID < 50600) {
+                $context['ssl'] += array(
+                    'SNI_server_name' => $args['hostname'],
+                    'CN_match' => $args['hostname']
+                );
+            }
+        }
+
         $socket = @stream_socket_client(
             $uri,
             $errno,
             $errstr,
             0,
             STREAM_CLIENT_CONNECT | STREAM_CLIENT_ASYNC_CONNECT,
-            stream_context_create(array('socket' => $this->context))
+            stream_context_create($context)
         );
 
         if (false === $socket) {


### PR DESCRIPTION
Resolves / closes #83
Supersedes / closes #66
Refs #69