### PR TITLE
Add main Connector facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,11 +307,38 @@ $connector = new Connector($loop, array(
     'unix' => false,
 ));
 
-$connector->connect('tcp://localhost:443')->then(function (ConnectionInterface $connection) {
+$connector->connect('tls://google.com:443')->then(function (ConnectionInterface $connection) {
     $connection->write('...');
     $connection->end();
 });
 ```
+
+The `tcp://` and `tls://` also accept additional context options passed to
+the underlying connectors.
+If you want to explicitly pass additional context options, you can simply
+pass arrays of context options like this:
+
+```php
+// allow insecure TLS connections
+$connector = new Connector($loop, array(
+    'tcp' => array(
+        'bindto' => '192.168.0.1:0'
+    ),
+    'tls' => array(
+        'verify_peer' => false,
+        'verify_peer_name' => false
+    ),
+));
+
+$connector->connect('tls://localhost:443')->then(function (ConnectionInterface $connection) {
+    $connection->write('...');
+    $connection->end();
+});
+```
+
+> For more details about context options, please refer to the PHP documentation
+  about [socket context options](http://php.net/manual/en/context.socket.php)
+  and [SSL context options](http://php.net/manual/en/context.ssl.php).
 
 ## Advanced Usage
 

--- a/README.md
+++ b/README.md
@@ -295,6 +295,24 @@ $connector->connect('localhost:80')->then(function (ConnectionInterface $connect
 });
 ```
 
+By default, the `Connector` supports the `tcp://`, `tls://` and `unix://`
+URI schemes. If you want to explicitly prohibit any of these, you can simply
+pass boolean flags like this:
+
+```php
+// only allow secure TLS connections
+$connector = new Connector($loop, array(
+    'tcp' => false,
+    'tls' => true,
+    'unix' => false,
+));
+
+$connector->connect('tcp://localhost:443')->then(function (ConnectionInterface $connection) {
+    $connection->write('...');
+    $connection->end();
+});
+```
+
 ## Advanced Usage
 
 ### TcpConnector

--- a/README.md
+++ b/README.md
@@ -24,11 +24,12 @@ handle multiple connections without blocking.
     * [getRemoteAddress()](#getremoteaddress)
     * [getLocalAddress()](#getlocaladdress)
   * [Connector](#connector)
-  * [Plaintext TCP/IP connections](#plaintext-tcpip-connections)
-  * [DNS resolution](#dns-resolution)
-  * [Secure TLS connections](#secure-tls-connections)
-  * [Connection timeout](#connection-timeouts)
-  * [Unix domain sockets](#unix-domain-sockets)
+* [Advanced Usage](#advanced-usage)
+  * [TcpConnector](#tcpconnector)
+  * [DnsConnector](#dnsconnector)
+  * [SecureConnector](#secureconnector)
+  * [TimeoutConnector](#timeoutconnector)
+  * [UnixConnector](#unixconnector)
 * [Install](#install)
 * [Tests](#tests)
 * [License](#license)
@@ -183,10 +184,11 @@ used for this connection.
 
 ### Connector
 
-The `Connector` class implements the
-[`ConnectorInterface`](#connectorinterface) and allows you to create any kind
-of streaming connections, such as plaintext TCP/IP, secure TLS or local Unix
-connection streams.
+The `Connector` class is the main class in this package that implements the
+[`ConnectorInterface`](#connectorinterface) and allows you to create streaming connections.
+
+You can use this connector to create any kind of streaming connections, such
+as plaintext TCP/IP, secure TLS or local Unix connection streams.
 
 It binds to the main event loop and can be used like this:
 
@@ -280,7 +282,9 @@ $connector->connect('127.0.0.1:80')->then(function (ConnectionInterface $connect
 });
 ```
 
-### Plaintext TCP/IP connections
+## Advanced Usage
+
+### TcpConnector
 
 The `React\SocketClient\TcpConnector` class implements the
 [`ConnectorInterface`](#connectorinterface) and allows you to create plaintext
@@ -339,7 +343,7 @@ be used to set up the TLS peer name.
 This is used by the `SecureConnector` and `DnsConnector` to verify the peer
 name and can also be used if you want a custom TLS peer name.
 
-### DNS resolution
+### DnsConnector
 
 The `DnsConnector` class implements the
 [`ConnectorInterface`](#connectorinterface) and allows you to create plaintext
@@ -399,7 +403,7 @@ hostname and is used by the `TcpConnector` to set up the TLS peer name.
 If a `hostname` is given explicitly, this query parameter will not be modified,
 which can be useful if you want a custom TLS peer name.
 
-### Secure TLS connections
+### SecureConnector
 
 The `SecureConnector` class implements the
 [`ConnectorInterface`](#connectorinterface) and allows you to create secure
@@ -453,7 +457,7 @@ Failing to do so may result in a TLS peer name mismatch error or some hard to
 trace race conditions, because all stream resources will use a single, shared
 *default context* resource otherwise.
 
-### Connection timeouts
+### TimeoutConnector
 
 The `TimeoutConnector` class implements the
 [`ConnectorInterface`](#connectorinterface) and allows you to add timeout
@@ -484,7 +488,7 @@ $promise->cancel();
 Calling `cancel()` on a pending promise will cancel the underlying connection
 attempt, abort the timer and reject the resulting promise.
 
-### Unix domain sockets
+### UnixConnector
 
 The `UnixConnector` class implements the
 [`ConnectorInterface`](#connectorinterface) and allows you to connect to

--- a/README.md
+++ b/README.md
@@ -295,6 +295,25 @@ $connector->connect('localhost:80')->then(function (ConnectionInterface $connect
 });
 ```
 
+By default, the `tcp://` and `tls://` URI schemes will use timeout value that
+repects your `default_socket_timeout` ini setting (which defaults to 60s).
+If you want a custom timeout value, you can simply pass this like this:
+
+```php
+$connector = new Connector($loop, array(
+    'timeout' => 10.0
+));
+```
+
+Similarly, if you do not want to apply a timeout at all and let the operating
+system handle this, you can pass a boolean flag like this:
+
+```php
+$connector = new Connector($loop, array(
+    'timeout' => false
+));
+```
+
 By default, the `Connector` supports the `tcp://`, `tls://` and `unix://`
 URI schemes. If you want to explicitly prohibit any of these, you can simply
 pass boolean flags like this:
@@ -357,9 +376,11 @@ $unix = new UnixConnector($loop);
 
 $connector = new Connector($loop, array(
     'tcp' => $tcp,
-    'dns' => false,
     'tls' => $tls,
     'unix' => $unix,
+
+    'dns' => false,
+    'timeout' => false,
 ));
 
 $connector->connect('google.com:80')->then(function (ConnectionInterface $connection) {
@@ -377,6 +398,8 @@ $connector->connect('google.com:80')->then(function (ConnectionInterface $connec
   TCP/IP connection before enabling secure TLS mode. If you want to use a custom
   underlying `tcp://` connector for secure TLS connections only, you may
   explicitly pass a `tls://` connector like above instead.
+  Internally, the `tcp://` and `tls://` connectors will always be wrapped by
+  `TimeoutConnector`, unless you disable timeouts like in the above example.
 
 ## Advanced Usage
 

--- a/examples/01-http.php
+++ b/examples/01-http.php
@@ -1,27 +1,17 @@
 <?php
 
 use React\EventLoop\Factory;
-use React\SocketClient\TcpConnector;
-use React\SocketClient\DnsConnector;
-use React\SocketClient\TimeoutConnector;
+use React\SocketClient\Connector;
 use React\SocketClient\ConnectionInterface;
+
+$target = isset($argv[1]) ? $argv[1] : 'www.google.com:80';
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
+$connector = new Connector($loop);
 
-$factory = new \React\Dns\Resolver\Factory();
-$resolver = $factory->create('8.8.8.8', $loop);
-
-$tcp = new TcpConnector($loop);
-$dns = new DnsConnector($tcp, $resolver);
-
-// time out connection attempt in 3.0s
-$dns = new TimeoutConnector($dns, 3.0, $loop);
-
-$target = isset($argv[1]) ? $argv[1] : 'www.google.com:80';
-
-$dns->connect($target)->then(function (ConnectionInterface $connection) use ($target) {
+$connector->connect($target)->then(function (ConnectionInterface $connection) use ($target) {
     $connection->on('data', function ($data) {
         echo $data;
     });

--- a/examples/02-https.php
+++ b/examples/02-https.php
@@ -1,29 +1,17 @@
 <?php
 
 use React\EventLoop\Factory;
-use React\SocketClient\TcpConnector;
-use React\SocketClient\DnsConnector;
-use React\SocketClient\SecureConnector;
-use React\SocketClient\TimeoutConnector;
+use React\SocketClient\Connector;
 use React\SocketClient\ConnectionInterface;
+
+$target = 'tls://' . (isset($argv[1]) ? $argv[1] : 'www.google.com:443');
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
+$connector = new Connector($loop);
 
-$factory = new \React\Dns\Resolver\Factory();
-$resolver = $factory->create('8.8.8.8', $loop);
-
-$tcp = new TcpConnector($loop);
-$dns = new DnsConnector($tcp, $resolver);
-$tls = new SecureConnector($dns, $loop);
-
-// time out connection attempt in 3.0s
-$tls = new TimeoutConnector($tls, 3.0, $loop);
-
-$target = isset($argv[1]) ? $argv[1] : 'www.google.com:443';
-
-$tls->connect($target)->then(function (ConnectionInterface $connection) use ($target) {
+$connector->connect($target)->then(function (ConnectionInterface $connection) use ($target) {
     $connection->on('data', function ($data) {
         echo $data;
     });

--- a/examples/02-https.php
+++ b/examples/02-https.php
@@ -4,14 +4,14 @@ use React\EventLoop\Factory;
 use React\SocketClient\Connector;
 use React\SocketClient\ConnectionInterface;
 
-$target = 'tls://' . (isset($argv[1]) ? $argv[1] : 'www.google.com:443');
+$target = isset($argv[1]) ? $argv[1] : 'www.google.com:443';
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 $connector = new Connector($loop);
 
-$connector->connect($target)->then(function (ConnectionInterface $connection) use ($target) {
+$connector->connect('tls://' . $target)->then(function (ConnectionInterface $connection) use ($target) {
     $connection->on('data', function ($data) {
         echo $data;
     });

--- a/examples/03-netcat.php
+++ b/examples/03-netcat.php
@@ -1,10 +1,9 @@
 <?php
 
 use React\EventLoop\Factory;
-use React\SocketClient\TcpConnector;
-use React\SocketClient\DnsConnector;
-use React\SocketClient\TimeoutConnector;
+use React\SocketClient\Connector;
 use React\SocketClient\ConnectionInterface;
+use React\Stream\Stream;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -14,15 +13,7 @@ if (!isset($argv[1])) {
 }
 
 $loop = Factory::create();
-
-$factory = new \React\Dns\Resolver\Factory();
-$resolver = $factory->create('8.8.8.8', $loop);
-
-$tcp = new TcpConnector($loop);
-$dns = new DnsConnector($tcp, $resolver);
-
-// time out connection attempt in 3.0s
-$dns = new TimeoutConnector($dns, 3.0, $loop);
+$connector = new Connector($loop);
 
 $stdin = new Stream(STDIN, $loop);
 $stdin->pause();
@@ -33,7 +24,7 @@ $stderr->pause();
 
 $stderr->write('Connecting' . PHP_EOL);
 
-$dns->connect($argv[1])->then(function (ConnectionInterface $connection) use ($stdin, $stdout, $stderr) {
+$connector->connect($argv[1])->then(function (ConnectionInterface $connection) use ($stdin, $stdout, $stderr) {
     // pipe everything from STDIN into connection
     $stdin->resume();
     $stdin->pipe($connection);

--- a/examples/04-web.php
+++ b/examples/04-web.php
@@ -1,0 +1,48 @@
+<?php
+
+use React\EventLoop\Factory;
+use React\SocketClient\ConnectionInterface;
+use React\SocketClient\Connector;
+use React\Stream\Stream;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$uri = isset($argv[1]) ? $argv[1] : 'www.google.com';
+
+if (strpos($uri, '://') === false) {
+    $uri = 'http://' . $uri;
+}
+$parts = parse_url($uri);
+
+if (!$parts || !isset($parts['scheme'], $parts['host'])) {
+    fwrite(STDERR, 'Usage error: required argument <host:port>' . PHP_EOL);
+    exit(1);
+}
+
+$loop = Factory::create();
+$connector = new Connector($loop);
+
+if (!isset($parts['port'])) {
+    $parts['port'] = $parts['scheme'] === 'https' ? 443 : 80;
+}
+
+$host = $parts['host'];
+if (($parts['scheme'] === 'http' && $parts['port'] !== 80) || ($parts['scheme'] === 'https' && $parts['port'] !== 443)) {
+    $host .= ':' . $parts['port'];
+}
+$target = ($parts['scheme'] === 'https' ? 'tls' : 'tcp') . '://' . $parts['host'] . ':' . $parts['port'];
+$resource = isset($parts['path']) ? $parts['path'] : '/';
+if (isset($parts['query'])) {
+    $resource .= '?' . $parts['query'];
+}
+
+$stdout = new Stream(STDOUT, $loop);
+$stdout->pause();
+
+$connector->connect($target)->then(function (ConnectionInterface $connection) use ($resource, $host, $stdout) {
+    $connection->pipe($stdout);
+
+    $connection->write("GET $resource HTTP/1.0\r\nHost: $host\r\n\r\n");
+}, 'printf');
+
+$loop->run();

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -37,10 +37,15 @@ final class Connector implements ConnectorInterface
             'unix' => true,
         );
 
-        $tcp = new TcpConnector(
-            $loop,
-            is_array($options['tcp']) ? $options['tcp'] : array()
-        );
+        if ($options['tcp'] instanceof ConnectorInterface) {
+            $tcp = $options['tcp'];
+        } else {
+            $tcp = new TcpConnector(
+                $loop,
+                is_array($options['tcp']) ? $options['tcp'] : array()
+            );
+        }
+
         if ($options['dns'] !== false) {
             if ($options['dns'] instanceof Resolver) {
                 $resolver = $options['dns'];
@@ -60,17 +65,21 @@ final class Connector implements ConnectorInterface
         }
 
         if ($options['tls'] !== false) {
-            $tls = new SecureConnector(
-                $tcp,
-                $loop,
-                is_array($options['tls']) ? $options['tls'] : array()
-            );
-            $this->connectors['tls'] = $tls;
+            if (!$options['tls'] instanceof ConnectorInterface) {
+                $options['tls'] = new SecureConnector(
+                    $tcp,
+                    $loop,
+                    is_array($options['tls']) ? $options['tls'] : array()
+                );
+            }
+            $this->connectors['tls'] = $options['tls'];
         }
 
         if ($options['unix'] !== false) {
-            $unix = new UnixConnector($loop);
-            $this->connectors['unix'] = $unix;
+            if (!$options['unix'] instanceof ConnectorInterface) {
+                $options['unix'] = new UnixConnector($loop);
+            }
+            $this->connectors['unix'] = $options['unix'];
         }
     }
 

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -37,7 +37,10 @@ final class Connector implements ConnectorInterface
             'unix' => true,
         );
 
-        $tcp = new TcpConnector($loop);
+        $tcp = new TcpConnector(
+            $loop,
+            is_array($options['tcp']) ? $options['tcp'] : array()
+        );
         if ($options['dns'] !== false) {
             if ($options['dns'] instanceof Resolver) {
                 $resolver = $options['dns'];
@@ -57,7 +60,11 @@ final class Connector implements ConnectorInterface
         }
 
         if ($options['tls'] !== false) {
-            $tls = new SecureConnector($tcp, $loop);
+            $tls = new SecureConnector(
+                $tcp,
+                $loop,
+                is_array($options['tls']) ? $options['tls'] : array()
+            );
             $this->connectors['tls'] = $tls;
         }
 

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -8,9 +8,11 @@ use React\Dns\Resolver\Factory;
 use InvalidArgumentException;
 
 /**
- * The `Connector` class implements the `ConnectorInterface` and allows you to
- * create any kind of streaming connections, such as plaintext TCP/IP, secure
- * TLS or local Unix connection streams.
+ * The `Connector` class is the main class in this package that implements the
+ * `ConnectorInterface` and allows you to create streaming connections.
+ *
+ * You can use this connector to create any kind of streaming connections, such
+ * as plaintext TCP/IP, secure TLS or local Unix connection streams.
  *
  * Under the hood, the `Connector` is implemented as a *higher-level facade*
  * or the lower-level connectors implemented in this package. This means it

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -4,28 +4,59 @@ namespace React\SocketClient;
 
 use React\EventLoop\LoopInterface;
 use React\Dns\Resolver\Resolver;
+use React\Dns\Resolver\Factory;
+use InvalidArgumentException;
 
 /**
- * Legacy Connector
+ * The `Connector` class implements the `ConnectorInterface` and allows you to
+ * create any kind of streaming connections, such as plaintext TCP/IP, secure
+ * TLS or local Unix connection streams.
  *
- * This class is not to be confused with the ConnectorInterface and should not
- * be used as a typehint.
+ * Under the hood, the `Connector` is implemented as a *higher-level facade*
+ * or the lower-level connectors implemented in this package. This means it
+ * also shares all of their features and implementation details.
+ * If you want to typehint in your higher-level protocol implementation, you SHOULD
+ * use the generic [`ConnectorInterface`](#connectorinterface) instead.
  *
- * @deprecated Exists for BC only, consider using the newer DnsConnector instead
- * @see DnsConnector for the newer replacement
  * @see ConnectorInterface for the base interface
  */
 final class Connector implements ConnectorInterface
 {
-    private $connector;
+    private $tcp;
+    private $tls;
+    private $unix;
 
-    public function __construct(LoopInterface $loop, Resolver $resolver)
+    public function __construct(LoopInterface $loop, ConnectorInterface $tcp = null)
     {
-        $this->connector = new DnsConnector(new TcpConnector($loop), $resolver);
+        if ($tcp === null) {
+            $factory = new Factory();
+            $resolver = $factory->create('8.8.8.8', $loop);
+
+            $tcp = new DnsConnector(new TcpConnector($loop), $resolver);
+        }
+
+        $this->tcp = $tcp;
+        $this->tls = new SecureConnector($tcp, $loop);
+        $this->unix = new UnixConnector($loop);
     }
 
     public function connect($uri)
     {
-        return $this->connector->connect($uri);
+        if (strpos($uri, '://') === false) {
+            $uri = 'tcp://' . $uri;
+        }
+
+        $scheme = (string)substr($uri, 0, strpos($uri, '://'));
+
+        if ($scheme === 'tcp') {
+            return $this->tcp->connect($uri);
+        } elseif ($scheme === 'tls') {
+            return $this->tls->connect($uri);
+        } elseif ($scheme === 'unix') {
+            return $this->unix->connect($uri);
+        } else{
+            return Promise\reject(new InvalidArgumentException('Unknown URI scheme given'));
+        }
     }
 }
+

--- a/tests/ConnectorTest.php
+++ b/tests/ConnectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace React\Tests\SocketClient;
+
+use React\SocketClient\Connector;
+use React\Promise\Promise;
+
+class ConnectorTest extends TestCase
+{
+    public function testConnectorWithUnknownSchemeAlwaysFails()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $connector = new Connector($loop);
+
+        $promise = $connector->connect('unknown://google.com:80');
+        $promise->then(null, $this->expectCallableOnce());
+    }
+
+    public function testConnectorUsesGivenResolverInstance()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $promise = new Promise(function () { });
+        $resolver = $this->getMockBuilder('React\Dns\Resolver\Resolver')->disableOriginalConstructor()->getMock();
+        $resolver->expects($this->once())->method('resolve')->with('google.com')->willReturn($promise);
+
+        $connector = new Connector($loop, array(
+            'dns' => $resolver
+        ));
+
+        $connector->connect('google.com:80');
+    }
+}

--- a/tests/ConnectorTest.php
+++ b/tests/ConnectorTest.php
@@ -11,8 +11,9 @@ class ConnectorTest extends TestCase
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
+        $promise = new Promise(function () { });
         $tcp = $this->getMockBuilder('React\SocketClient\ConnectorInterface')->getMock();
-        $tcp->expects($this->once())->method('connect')->with('127.0.0.1:80');
+        $tcp->expects($this->once())->method('connect')->with('127.0.0.1:80')->willReturn($promise);
 
         $connector = new Connector($loop, array(
             'tcp' => $tcp
@@ -25,8 +26,9 @@ class ConnectorTest extends TestCase
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
+        $promise = new Promise(function () { });
         $tcp = $this->getMockBuilder('React\SocketClient\ConnectorInterface')->getMock();
-        $tcp->expects($this->once())->method('connect')->with('tcp://google.com:80');
+        $tcp->expects($this->once())->method('connect')->with('tcp://google.com:80')->willReturn($promise);
 
         $connector = new Connector($loop, array(
             'tcp' => $tcp,
@@ -112,8 +114,9 @@ class ConnectorTest extends TestCase
         $resolver = $this->getMockBuilder('React\Dns\Resolver\Resolver')->disableOriginalConstructor()->getMock();
         $resolver->expects($this->once())->method('resolve')->with('google.com')->willReturn($promise);
 
+        $promise = new Promise(function () { });
         $tcp = $this->getMockBuilder('React\SocketClient\ConnectorInterface')->getMock();
-        $tcp->expects($this->once())->method('connect')->with('tcp://127.0.0.1:80?hostname=google.com');
+        $tcp->expects($this->once())->method('connect')->with('tcp://127.0.0.1:80?hostname=google.com')->willReturn($promise);
 
         $connector = new Connector($loop, array(
             'tcp' => $tcp,

--- a/tests/ConnectorTest.php
+++ b/tests/ConnectorTest.php
@@ -16,6 +16,50 @@ class ConnectorTest extends TestCase
         $promise->then(null, $this->expectCallableOnce());
     }
 
+    public function testConnectorWithDisabledTcpDefaultSchemeAlwaysFails()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $connector = new Connector($loop, array(
+            'tcp' => false
+        ));
+
+        $promise = $connector->connect('google.com:80');
+        $promise->then(null, $this->expectCallableOnce());
+    }
+
+    public function testConnectorWithDisabledTcpSchemeAlwaysFails()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $connector = new Connector($loop, array(
+            'tcp' => false
+        ));
+
+        $promise = $connector->connect('tcp://google.com:80');
+        $promise->then(null, $this->expectCallableOnce());
+    }
+
+    public function testConnectorWithDisabledTlsSchemeAlwaysFails()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $connector = new Connector($loop, array(
+            'tls' => false
+        ));
+
+        $promise = $connector->connect('tls://google.com:443');
+        $promise->then(null, $this->expectCallableOnce());
+    }
+
+    public function testConnectorWithDisabledUnixSchemeAlwaysFails()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $connector = new Connector($loop, array(
+            'unix' => false
+        ));
+
+        $promise = $connector->connect('unix://demo.sock');
+        $promise->then(null, $this->expectCallableOnce());
+    }
+
     public function testConnectorUsesGivenResolverInstance()
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -4,7 +4,6 @@ namespace React\Tests\SocketClient;
 
 use React\Dns\Resolver\Factory;
 use React\EventLoop\StreamSelectLoop;
-use React\Socket\Server;
 use React\SocketClient\Connector;
 use React\SocketClient\SecureConnector;
 use React\SocketClient\TcpConnector;
@@ -20,10 +19,7 @@ class IntegrationTest extends TestCase
     public function gettingStuffFromGoogleShouldWork()
     {
         $loop = new StreamSelectLoop();
-
-        $factory = new Factory();
-        $dns = $factory->create('8.8.8.8', $loop);
-        $connector = new Connector($loop, $dns);
+        $connector = new Connector($loop);
 
         $conn = Block\await($connector->connect('google.com:80'), $loop);
 
@@ -45,16 +41,9 @@ class IntegrationTest extends TestCase
         }
 
         $loop = new StreamSelectLoop();
+        $secureConnector = new Connector($loop);
 
-        $factory = new Factory();
-        $dns = $factory->create('8.8.8.8', $loop);
-
-        $secureConnector = new SecureConnector(
-            new Connector($loop, $dns),
-            $loop
-        );
-
-        $conn = Block\await($secureConnector->connect('google.com:443'), $loop);
+        $conn = Block\await($secureConnector->connect('tls://google.com:443'), $loop);
 
         $conn->write("GET / HTTP/1.0\r\n\r\n");
 
@@ -101,11 +90,8 @@ class IntegrationTest extends TestCase
 
         $loop = new StreamSelectLoop();
 
-        $factory = new Factory();
-        $dns = $factory->create('8.8.8.8', $loop);
-
         $secureConnector = new SecureConnector(
-            new Connector($loop, $dns),
+            new Connector($loop),
             $loop,
             array(
                 'verify_peer' => true
@@ -125,11 +111,8 @@ class IntegrationTest extends TestCase
 
         $loop = new StreamSelectLoop();
 
-        $factory = new Factory();
-        $dns = $factory->create('8.8.8.8', $loop);
-
         $secureConnector = new SecureConnector(
-            new Connector($loop, $dns),
+            new Connector($loop),
             $loop,
             array(
                 'verify_peer' => false

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -82,6 +82,26 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
+    public function testConnectingFailsIfDnsUsesInvalidResolver()
+    {
+        if (!function_exists('stream_socket_enable_crypto')) {
+            $this->markTestSkipped('Not supported on your platform (outdated HHVM?)');
+        }
+
+        $loop = new StreamSelectLoop();
+
+        $factory = new Factory();
+        $dns = $factory->create('demo.invalid', $loop);
+
+        $connector = new Connector($loop, array(
+            'dns' => $dns
+        ));
+
+        $this->setExpectedException('RuntimeException');
+        Block\await($connector->connect('google.com:80'), $loop, self::TIMEOUT);
+    }
+
+    /** @test */
     public function testSelfSignedRejectsIfVerificationIsEnabled()
     {
         if (!function_exists('stream_socket_enable_crypto')) {

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -84,10 +84,6 @@ class IntegrationTest extends TestCase
     /** @test */
     public function testConnectingFailsIfDnsUsesInvalidResolver()
     {
-        if (!function_exists('stream_socket_enable_crypto')) {
-            $this->markTestSkipped('Not supported on your platform (outdated HHVM?)');
-        }
-
         $loop = new StreamSelectLoop();
 
         $factory = new Factory();
@@ -95,6 +91,23 @@ class IntegrationTest extends TestCase
 
         $connector = new Connector($loop, array(
             'dns' => $dns
+        ));
+
+        $this->setExpectedException('RuntimeException');
+        Block\await($connector->connect('google.com:80'), $loop, self::TIMEOUT);
+    }
+
+    /** @test */
+    public function testConnectingFailsIfTimeoutIsTooSmall()
+    {
+        if (!function_exists('stream_socket_enable_crypto')) {
+            $this->markTestSkipped('Not supported on your platform (outdated HHVM?)');
+        }
+
+        $loop = new StreamSelectLoop();
+
+        $connector = new Connector($loop, array(
+            'timeout' => 0.001
         ));
 
         $this->setExpectedException('RuntimeException');

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -110,16 +110,14 @@ class IntegrationTest extends TestCase
 
         $loop = new StreamSelectLoop();
 
-        $secureConnector = new SecureConnector(
-            new Connector($loop),
-            $loop,
-            array(
+        $connector = new Connector($loop, array(
+            'tls' => array(
                 'verify_peer' => true
             )
-        );
+        ));
 
         $this->setExpectedException('RuntimeException');
-        Block\await($secureConnector->connect('self-signed.badssl.com:443'), $loop, self::TIMEOUT);
+        Block\await($connector->connect('tls://self-signed.badssl.com:443'), $loop, self::TIMEOUT);
     }
 
     /** @test */
@@ -131,15 +129,13 @@ class IntegrationTest extends TestCase
 
         $loop = new StreamSelectLoop();
 
-        $secureConnector = new SecureConnector(
-            new Connector($loop),
-            $loop,
-            array(
+        $connector = new Connector($loop, array(
+            'tls' => array(
                 'verify_peer' => false
             )
-        );
+        ));
 
-        $conn = Block\await($secureConnector->connect('self-signed.badssl.com:443'), $loop, self::TIMEOUT);
+        $conn = Block\await($connector->connect('tls://self-signed.badssl.com:443'), $loop, self::TIMEOUT);
         $conn->close();
     }
 


### PR DESCRIPTION
This PR adds a new `Connector` class that acts as a facade for all underlying connectors, which are now marked as "advanced usage", but continue to work unchanged.

The `Connector` class now makes it trivially easy to create plaintext TCP/IP, secure TLS and Unix domain socket connection streams like this:

```php
$connector = new Connector($loop);

$connector->connect('tls://google.com:443')->then(function (ConnectionInterface $conn) {
    $conn->write('…');
});
```

Resolves / closes #38 